### PR TITLE
realm-primary-keys: Changed primary keys to be a `pk` property on `Resource`, instead of `id`

### DIFF
--- a/realm-swift-fhir/RealmSwiftFHIR.xcodeproj/xcshareddata/xcschemes/RealmSwiftFHIR-iOS.xcscheme
+++ b/realm-swift-fhir/RealmSwiftFHIR.xcodeproj/xcshareddata/xcschemes/RealmSwiftFHIR-iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C2AF41E41E37C4E300EE1AEE"
-               BuildableName = "RealmSwiftFHIR-iOS.framework"
+               BuildableName = "RealmSwiftFHIR.framework"
                BlueprintName = "RealmSwiftFHIR-iOS"
                ReferencedContainer = "container:RealmSwiftFHIR.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C2AF41E41E37C4E300EE1AEE"
-            BuildableName = "RealmSwiftFHIR-iOS.framework"
+            BuildableName = "RealmSwiftFHIR.framework"
             BlueprintName = "RealmSwiftFHIR-iOS"
             ReferencedContainer = "container:RealmSwiftFHIR.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C2AF41E41E37C4E300EE1AEE"
-            BuildableName = "RealmSwiftFHIR-iOS.framework"
+            BuildableName = "RealmSwiftFHIR.framework"
             BlueprintName = "RealmSwiftFHIR-iOS"
             ReferencedContainer = "container:RealmSwiftFHIR.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C2AF41E41E37C4E300EE1AEE"
-            BuildableName = "RealmSwiftFHIR-iOS.framework"
+            BuildableName = "RealmSwiftFHIR.framework"
             BlueprintName = "RealmSwiftFHIR-iOS"
             ReferencedContainer = "container:RealmSwiftFHIR.xcodeproj">
          </BuildableReference>

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Account.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Account.swift
@@ -2,7 +2,7 @@
 //  Account.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Account) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Account) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,16 +22,27 @@ open class Account: DomainResource {
 	}
 
 	public dynamic var activePeriod: Period?
+	
 	public dynamic var balance: Quantity?
+	
 	public dynamic var coveragePeriod: Period?
+	
 	public dynamic var currency: Coding?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var owner: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -77,6 +88,7 @@ open class Account: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -97,6 +109,7 @@ open class Account: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -115,6 +128,7 @@ open class Account: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Address.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Address.swift
@@ -2,7 +2,7 @@
 //  Address.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Address) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Address) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,15 +22,25 @@ open class Address: Element {
 	}
 
 	public dynamic var city: String?
+	
 	public dynamic var country: String?
+	
 	public dynamic var district: String?
+	
 	public let line = RealmSwift.List<RealmString>()
+	
 	public dynamic var period: Period?
+	
 	public dynamic var postalCode: String?
+	
 	public dynamic var state: String?
+	
 	public dynamic var text: String?
+	
 	public dynamic var type: String?
+	
 	public dynamic var use: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -40,6 +50,7 @@ open class Address: Element {
 				presentKeys.insert("city")
 				if let val = exist as? String {
 					self.city = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "city", wants: String.self, has: type(of: exist)))
@@ -49,6 +60,7 @@ open class Address: Element {
 				presentKeys.insert("country")
 				if let val = exist as? String {
 					self.country = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "country", wants: String.self, has: type(of: exist)))
@@ -58,6 +70,7 @@ open class Address: Element {
 				presentKeys.insert("district")
 				if let val = exist as? String {
 					self.district = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "district", wants: String.self, has: type(of: exist)))
@@ -85,6 +98,7 @@ open class Address: Element {
 				presentKeys.insert("postalCode")
 				if let val = exist as? String {
 					self.postalCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "postalCode", wants: String.self, has: type(of: exist)))
@@ -94,6 +108,7 @@ open class Address: Element {
 				presentKeys.insert("state")
 				if let val = exist as? String {
 					self.state = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "state", wants: String.self, has: type(of: exist)))
@@ -103,6 +118,7 @@ open class Address: Element {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -112,6 +128,7 @@ open class Address: Element {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -121,6 +138,7 @@ open class Address: Element {
 				presentKeys.insert("use")
 				if let val = exist as? String {
 					self.use = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "use", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Age.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Age.swift
@@ -2,7 +2,7 @@
 //  Age.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Age) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Age) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/AllergyIntolerance.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/AllergyIntolerance.swift
@@ -2,7 +2,7 @@
 //  AllergyIntolerance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AllergyIntolerance) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AllergyIntolerance) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,19 +22,33 @@ open class AllergyIntolerance: DomainResource {
 	}
 
 	public dynamic var category: String?
+	
 	public dynamic var criticality: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var lastOccurence: DateTime?
+	
 	public dynamic var note: Annotation?
+	
 	public dynamic var onset: DateTime?
+	
 	public dynamic var patient: Reference?
+	
 	public let reaction = RealmSwift.List<AllergyIntoleranceReaction>()
+	
 	public dynamic var recordedDate: DateTime?
+	
 	public dynamic var recorder: Reference?
+	
 	public dynamic var reporter: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var substance: CodeableConcept?
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -51,6 +65,7 @@ open class AllergyIntolerance: DomainResource {
 				presentKeys.insert("category")
 				if let val = exist as? String {
 					self.category = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "category", wants: String.self, has: type(of: exist)))
@@ -60,6 +75,7 @@ open class AllergyIntolerance: DomainResource {
 				presentKeys.insert("criticality")
 				if let val = exist as? String {
 					self.criticality = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "criticality", wants: String.self, has: type(of: exist)))
@@ -157,6 +173,7 @@ open class AllergyIntolerance: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -178,6 +195,7 @@ open class AllergyIntolerance: DomainResource {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -249,13 +267,21 @@ open class AllergyIntoleranceReaction: BackboneElement {
 	}
 
 	public dynamic var certainty: String?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var exposureRoute: CodeableConcept?
+	
 	public let manifestation = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var note: Annotation?
+	
 	public dynamic var onset: DateTime?
+	
 	public dynamic var severity: String?
+	
 	public dynamic var substance: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -271,6 +297,7 @@ open class AllergyIntoleranceReaction: BackboneElement {
 				presentKeys.insert("certainty")
 				if let val = exist as? String {
 					self.certainty = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "certainty", wants: String.self, has: type(of: exist)))
@@ -280,6 +307,7 @@ open class AllergyIntoleranceReaction: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -330,6 +358,7 @@ open class AllergyIntoleranceReaction: BackboneElement {
 				presentKeys.insert("severity")
 				if let val = exist as? String {
 					self.severity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "severity", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Annotation.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Annotation.swift
@@ -2,7 +2,7 @@
 //  Annotation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Annotation) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Annotation) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,9 +21,13 @@ open class Annotation: Element {
 	}
 
 	public dynamic var authorReference: Reference?
+	
 	public dynamic var authorString: String?
+	
 	public dynamic var text: String?
+	
 	public dynamic var time: DateTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -48,6 +52,7 @@ open class Annotation: Element {
 				presentKeys.insert("authorString")
 				if let val = exist as? String {
 					self.authorString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "authorString", wants: String.self, has: type(of: exist)))
@@ -57,6 +62,7 @@ open class Annotation: Element {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Appointment.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Appointment.swift
@@ -2,7 +2,7 @@
 //  Appointment.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Appointment) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Appointment) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -20,17 +20,29 @@ open class Appointment: DomainResource {
 	}
 
 	public dynamic var comment: String?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var end: Instant?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let minutesDuration = RealmOptional<Int>()
+	
 	public let participant = RealmSwift.List<AppointmentParticipant>()
+	
 	public let priority = RealmOptional<Int>()
+	
 	public dynamic var reason: CodeableConcept?
+	
 	public let slot = RealmSwift.List<Reference>()
+	
 	public dynamic var start: Instant?
+	
 	public dynamic var status: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -47,6 +59,7 @@ open class Appointment: DomainResource {
 				presentKeys.insert("comment")
 				if let val = exist as? String {
 					self.comment = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comment", wants: String.self, has: type(of: exist)))
@@ -56,6 +69,7 @@ open class Appointment: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -85,6 +99,7 @@ open class Appointment: DomainResource {
 				presentKeys.insert("minutesDuration")
 				if let val = exist as? Int {
 					self.minutesDuration.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minutesDuration", wants: Int.self, has: type(of: exist)))
@@ -108,6 +123,7 @@ open class Appointment: DomainResource {
 				presentKeys.insert("priority")
 				if let val = exist as? Int {
 					self.priority.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "priority", wants: Int.self, has: type(of: exist)))
@@ -146,6 +162,7 @@ open class Appointment: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -223,9 +240,13 @@ open class AppointmentParticipant: BackboneElement {
 	}
 
 	public dynamic var actor: Reference?
+	
 	public dynamic var required: String?
+	
 	public dynamic var status: String?
+	
 	public let type = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -250,6 +271,7 @@ open class AppointmentParticipant: BackboneElement {
 				presentKeys.insert("required")
 				if let val = exist as? String {
 					self.required = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "required", wants: String.self, has: type(of: exist)))
@@ -259,6 +281,7 @@ open class AppointmentParticipant: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/AppointmentResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/AppointmentResponse.swift
@@ -2,7 +2,7 @@
 //  AppointmentResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AppointmentResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AppointmentResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,13 +19,21 @@ open class AppointmentResponse: DomainResource {
 	}
 
 	public dynamic var actor: Reference?
+	
 	public dynamic var appointment: Reference?
+	
 	public dynamic var comment: String?
+	
 	public dynamic var end: Instant?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var participantStatus: String?
+	
 	public let participantType = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var start: Instant?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -63,6 +71,7 @@ open class AppointmentResponse: DomainResource {
 				presentKeys.insert("comment")
 				if let val = exist as? String {
 					self.comment = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comment", wants: String.self, has: type(of: exist)))
@@ -92,6 +101,7 @@ open class AppointmentResponse: DomainResource {
 				presentKeys.insert("participantStatus")
 				if let val = exist as? String {
 					self.participantStatus = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "participantStatus", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Attachment.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Attachment.swift
@@ -2,7 +2,7 @@
 //  Attachment.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Attachment) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Attachment) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,13 +21,21 @@ open class Attachment: Element {
 	}
 
 	public dynamic var contentType: String?
+	
 	public dynamic var creation: DateTime?
+	
 	public dynamic var data: Base64Binary?
+	
 	public dynamic var hash_fhir: Base64Binary?
+	
 	public dynamic var language: String?
+	
 	public let size = RealmOptional<Int>()
+	
 	public dynamic var title: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -37,6 +45,7 @@ open class Attachment: Element {
 				presentKeys.insert("contentType")
 				if let val = exist as? String {
 					self.contentType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentType", wants: String.self, has: type(of: exist)))
@@ -73,6 +82,7 @@ open class Attachment: Element {
 				presentKeys.insert("language")
 				if let val = exist as? String {
 					self.language = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "language", wants: String.self, has: type(of: exist)))
@@ -82,6 +92,7 @@ open class Attachment: Element {
 				presentKeys.insert("size")
 				if let val = exist as? Int {
 					self.size.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "size", wants: Int.self, has: type(of: exist)))
@@ -91,6 +102,7 @@ open class Attachment: Element {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))
@@ -100,6 +112,7 @@ open class Attachment: Element {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/AuditEvent.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/AuditEvent.swift
@@ -2,7 +2,7 @@
 //  AuditEvent.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AuditEvent) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AuditEvent) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,9 +22,13 @@ open class AuditEvent: DomainResource {
 	}
 
 	public dynamic var event: AuditEventEvent?
+	
 	public let object = RealmSwift.List<AuditEventObject>()
+	
 	public let participant = RealmSwift.List<AuditEventParticipant>()
+	
 	public dynamic var source: AuditEventSource?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -123,12 +127,19 @@ open class AuditEventEvent: BackboneElement {
 	}
 
 	public dynamic var action: String?
+	
 	public dynamic var dateTime: Instant?
+	
 	public dynamic var outcome: String?
+	
 	public dynamic var outcomeDesc: String?
+	
 	public let purposeOfEvent = RealmSwift.List<Coding>()
+	
 	public let subtype = RealmSwift.List<Coding>()
+	
 	public dynamic var type: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -145,6 +156,7 @@ open class AuditEventEvent: BackboneElement {
 				presentKeys.insert("action")
 				if let val = exist as? String {
 					self.action = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "action", wants: String.self, has: type(of: exist)))
@@ -166,6 +178,7 @@ open class AuditEventEvent: BackboneElement {
 				presentKeys.insert("outcome")
 				if let val = exist as? String {
 					self.outcome = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcome", wants: String.self, has: type(of: exist)))
@@ -175,6 +188,7 @@ open class AuditEventEvent: BackboneElement {
 				presentKeys.insert("outcomeDesc")
 				if let val = exist as? String {
 					self.outcomeDesc = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcomeDesc", wants: String.self, has: type(of: exist)))
@@ -257,15 +271,25 @@ open class AuditEventObject: BackboneElement {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public let detail = RealmSwift.List<AuditEventObjectDetail>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var lifecycle: Coding?
+	
 	public dynamic var name: String?
+	
 	public dynamic var query: Base64Binary?
+	
 	public dynamic var reference: Reference?
+	
 	public dynamic var role: Coding?
+	
 	public let securityLabel = RealmSwift.List<Coding>()
+	
 	public dynamic var type: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -275,6 +299,7 @@ open class AuditEventObject: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -313,6 +338,7 @@ open class AuditEventObject: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -417,7 +443,9 @@ open class AuditEventObjectDetail: BackboneElement {
 	}
 
 	public dynamic var type: String?
+	
 	public dynamic var value: Base64Binary?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -434,6 +462,7 @@ open class AuditEventObjectDetail: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -482,16 +511,27 @@ open class AuditEventParticipant: BackboneElement {
 	}
 
 	public dynamic var altId: String?
+	
 	public dynamic var location: Reference?
+	
 	public dynamic var media: Coding?
+	
 	public dynamic var name: String?
+	
 	public dynamic var network: AuditEventParticipantNetwork?
+	
 	public let policy = RealmSwift.List<RealmString>()
+	
 	public let purposeOfUse = RealmSwift.List<Coding>()
+	
 	public dynamic var reference: Reference?
+	
 	public let requestor = RealmOptional<Bool>()
+	
 	public let role = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var userId: Identifier?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -507,6 +547,7 @@ open class AuditEventParticipant: BackboneElement {
 				presentKeys.insert("altId")
 				if let val = exist as? String {
 					self.altId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "altId", wants: String.self, has: type(of: exist)))
@@ -534,6 +575,7 @@ open class AuditEventParticipant: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -581,6 +623,7 @@ open class AuditEventParticipant: BackboneElement {
 				presentKeys.insert("requestor")
 				if let val = exist as? Bool {
 					self.requestor.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requestor", wants: Bool.self, has: type(of: exist)))
@@ -666,7 +709,9 @@ open class AuditEventParticipantNetwork: BackboneElement {
 	}
 
 	public dynamic var address: String?
+	
 	public dynamic var type: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -676,6 +721,7 @@ open class AuditEventParticipantNetwork: BackboneElement {
 				presentKeys.insert("address")
 				if let val = exist as? String {
 					self.address = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "address", wants: String.self, has: type(of: exist)))
@@ -685,6 +731,7 @@ open class AuditEventParticipantNetwork: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -718,8 +765,11 @@ open class AuditEventSource: BackboneElement {
 	}
 
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var site: String?
+	
 	public let type = RealmSwift.List<Coding>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -747,6 +797,7 @@ open class AuditEventSource: BackboneElement {
 				presentKeys.insert("site")
 				if let val = exist as? String {
 					self.site = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "site", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/BackboneElement.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/BackboneElement.swift
@@ -2,7 +2,7 @@
 //  BackboneElement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BackboneElement) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BackboneElement) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,6 +21,7 @@ open class BackboneElement: Element {
 	}
 
 	public let modifierExtension = RealmSwift.List<Extension>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Basic.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Basic.swift
@@ -2,7 +2,7 @@
 //  Basic.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Basic) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Basic) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,10 +22,15 @@ open class Basic: DomainResource {
 	}
 
 	public dynamic var author: Reference?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var created: FHIRDate?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Binary.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Binary.swift
@@ -2,7 +2,7 @@
 //  Binary.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Binary) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Binary) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,7 +21,9 @@ open class Binary: Resource {
 	}
 
 	public dynamic var content: Base64Binary?
+	
 	public dynamic var contentType: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -50,6 +52,7 @@ open class Binary: Resource {
 				presentKeys.insert("contentType")
 				if let val = exist as? String {
 					self.contentType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentType", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/BodySite.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/BodySite.swift
@@ -2,7 +2,7 @@
 //  BodySite.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BodySite) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BodySite) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,11 +22,17 @@ open class BodySite: DomainResource {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let image = RealmSwift.List<Attachment>()
+	
 	public let modifier = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var patient: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -51,6 +57,7 @@ open class BodySite: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Bundle.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Bundle.swift
@@ -2,7 +2,7 @@
 //  Bundle.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Bundle) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Bundle) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,10 +21,15 @@ open class Bundle: Resource {
 	}
 
 	public let entry = RealmSwift.List<BundleEntry>()
+	
 	public let link = RealmSwift.List<BundleLink>()
+	
 	public dynamic var signature: Signature?
+	
 	public let total = RealmOptional<Int>()
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -71,6 +76,7 @@ open class Bundle: Resource {
 				presentKeys.insert("total")
 				if let val = exist as? Int {
 					self.total.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "total", wants: Int.self, has: type(of: exist)))
@@ -80,6 +86,7 @@ open class Bundle: Resource {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -128,11 +135,17 @@ open class BundleEntry: BackboneElement {
 	}
 
 	public dynamic var fullUrl: String?
+	
 	public let link = RealmSwift.List<BundleLink>()
+	
 	public dynamic var request: BundleEntryRequest?
+	
 	public dynamic var resource: Resource?
+	
 	public dynamic var response: BundleEntryResponse?
+	
 	public dynamic var search: BundleEntrySearch?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -142,6 +155,7 @@ open class BundleEntry: BackboneElement {
 				presentKeys.insert("fullUrl")
 				if let val = exist as? String {
 					self.fullUrl = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fullUrl", wants: String.self, has: type(of: exist)))
@@ -236,11 +250,17 @@ open class BundleEntryRequest: BackboneElement {
 	}
 
 	public dynamic var ifMatch: String?
+	
 	public dynamic var ifModifiedSince: Instant?
+	
 	public dynamic var ifNoneExist: String?
+	
 	public dynamic var ifNoneMatch: String?
+	
 	public dynamic var method: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -257,6 +277,7 @@ open class BundleEntryRequest: BackboneElement {
 				presentKeys.insert("ifMatch")
 				if let val = exist as? String {
 					self.ifMatch = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "ifMatch", wants: String.self, has: type(of: exist)))
@@ -275,6 +296,7 @@ open class BundleEntryRequest: BackboneElement {
 				presentKeys.insert("ifNoneExist")
 				if let val = exist as? String {
 					self.ifNoneExist = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "ifNoneExist", wants: String.self, has: type(of: exist)))
@@ -284,6 +306,7 @@ open class BundleEntryRequest: BackboneElement {
 				presentKeys.insert("ifNoneMatch")
 				if let val = exist as? String {
 					self.ifNoneMatch = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "ifNoneMatch", wants: String.self, has: type(of: exist)))
@@ -293,6 +316,7 @@ open class BundleEntryRequest: BackboneElement {
 				presentKeys.insert("method")
 				if let val = exist as? String {
 					self.method = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "method", wants: String.self, has: type(of: exist)))
@@ -305,6 +329,7 @@ open class BundleEntryRequest: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -355,9 +380,13 @@ open class BundleEntryResponse: BackboneElement {
 	}
 
 	public dynamic var etag: String?
+	
 	public dynamic var lastModified: Instant?
+	
 	public dynamic var location: String?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -373,6 +402,7 @@ open class BundleEntryResponse: BackboneElement {
 				presentKeys.insert("etag")
 				if let val = exist as? String {
 					self.etag = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "etag", wants: String.self, has: type(of: exist)))
@@ -391,6 +421,7 @@ open class BundleEntryResponse: BackboneElement {
 				presentKeys.insert("location")
 				if let val = exist as? String {
 					self.location = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "location", wants: String.self, has: type(of: exist)))
@@ -400,6 +431,7 @@ open class BundleEntryResponse: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -444,7 +476,9 @@ open class BundleEntrySearch: BackboneElement {
 	}
 
 	public dynamic var mode: String?
+	
 	public dynamic var score: RealmDecimal?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -454,6 +488,7 @@ open class BundleEntrySearch: BackboneElement {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -498,7 +533,9 @@ open class BundleLink: BackboneElement {
 	}
 
 	public dynamic var relation: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -515,6 +552,7 @@ open class BundleLink: BackboneElement {
 				presentKeys.insert("relation")
 				if let val = exist as? String {
 					self.relation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "relation", wants: String.self, has: type(of: exist)))
@@ -527,6 +565,7 @@ open class BundleLink: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/CarePlan.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/CarePlan.swift
@@ -2,7 +2,7 @@
 //  CarePlan.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CarePlan) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CarePlan) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,21 +22,37 @@ open class CarePlan: DomainResource {
 	}
 
 	public let activity = RealmSwift.List<CarePlanActivity>()
+	
 	public let addresses = RealmSwift.List<Reference>()
+	
 	public let author = RealmSwift.List<Reference>()
+	
 	public let category = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var context: Reference?
+	
 	public dynamic var description_fhir: String?
+	
 	public let goal = RealmSwift.List<Reference>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var modified: DateTime?
+	
 	public dynamic var note: Annotation?
+	
 	public let participant = RealmSwift.List<CarePlanParticipant>()
+	
 	public dynamic var period: Period?
+	
 	public let relatedPlan = RealmSwift.List<CarePlanRelatedPlan>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public let support = RealmSwift.List<Reference>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -105,6 +121,7 @@ open class CarePlan: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -185,6 +202,7 @@ open class CarePlan: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -286,9 +304,13 @@ open class CarePlanActivity: BackboneElement {
 	}
 
 	public let actionResulting = RealmSwift.List<Reference>()
+	
 	public dynamic var detail: CarePlanActivityDetail?
+	
 	public let progress = RealmSwift.List<Annotation>()
+	
 	public dynamic var reference: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -371,23 +393,41 @@ open class CarePlanActivityDetail: BackboneElement {
 	}
 
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var dailyAmount: Quantity?
+	
 	public dynamic var description_fhir: String?
+	
 	public let goal = RealmSwift.List<Reference>()
+	
 	public dynamic var location: Reference?
+	
 	public let performer = RealmSwift.List<Reference>()
+	
 	public dynamic var productCodeableConcept: CodeableConcept?
+	
 	public dynamic var productReference: Reference?
+	
 	public let prohibited = RealmOptional<Bool>()
+	
 	public dynamic var quantity: Quantity?
+	
 	public let reasonCode = RealmSwift.List<CodeableConcept>()
+	
 	public let reasonReference = RealmSwift.List<Reference>()
+	
 	public dynamic var scheduledPeriod: Period?
+	
 	public dynamic var scheduledString: String?
+	
 	public dynamic var scheduledTiming: Timing?
+	
 	public dynamic var status: String?
+	
 	public dynamic var statusReason: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -430,6 +470,7 @@ open class CarePlanActivityDetail: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -488,6 +529,7 @@ open class CarePlanActivityDetail: BackboneElement {
 				presentKeys.insert("prohibited")
 				if let val = exist as? Bool {
 					self.prohibited.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "prohibited", wants: Bool.self, has: type(of: exist)))
@@ -540,6 +582,7 @@ open class CarePlanActivityDetail: BackboneElement {
 				presentKeys.insert("scheduledString")
 				if let val = exist as? String {
 					self.scheduledString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "scheduledString", wants: String.self, has: type(of: exist)))
@@ -558,6 +601,7 @@ open class CarePlanActivityDetail: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -650,7 +694,9 @@ open class CarePlanParticipant: BackboneElement {
 	}
 
 	public dynamic var member: Reference?
+	
 	public dynamic var role: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -704,7 +750,9 @@ open class CarePlanRelatedPlan: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var plan: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -720,6 +768,7 @@ open class CarePlanRelatedPlan: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Claim.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Claim.swift
@@ -2,7 +2,7 @@
 //  Claim.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Claim) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Claim) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,34 +22,63 @@ open class Claim: DomainResource {
 	}
 
 	public dynamic var accident: FHIRDate?
+	
 	public dynamic var accidentType: Coding?
+	
 	public let additionalMaterials = RealmSwift.List<Coding>()
+	
 	public let condition = RealmSwift.List<Coding>()
+	
 	public let coverage = RealmSwift.List<ClaimCoverage>()
+	
 	public dynamic var created: DateTime?
+	
 	public let diagnosis = RealmSwift.List<ClaimDiagnosis>()
+	
 	public dynamic var enterer: Reference?
+	
 	public let exception = RealmSwift.List<Coding>()
+	
 	public dynamic var facility: Reference?
+	
 	public dynamic var fundsReserve: Coding?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let interventionException = RealmSwift.List<Coding>()
+	
 	public let item = RealmSwift.List<ClaimItem>()
+	
 	public let missingTeeth = RealmSwift.List<ClaimMissingTeeth>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalPrescription: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var payee: ClaimPayee?
+	
 	public dynamic var prescription: Reference?
+	
 	public dynamic var priority: Coding?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var referral: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var school: String?
+	
 	public dynamic var target: Reference?
+	
 	public dynamic var type: String?
+	
 	public dynamic var use: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -312,6 +341,7 @@ open class Claim: DomainResource {
 				presentKeys.insert("school")
 				if let val = exist as? String {
 					self.school = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "school", wants: String.self, has: type(of: exist)))
@@ -330,6 +360,7 @@ open class Claim: DomainResource {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -342,6 +373,7 @@ open class Claim: DomainResource {
 				presentKeys.insert("use")
 				if let val = exist as? String {
 					self.use = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "use", wants: String.self, has: type(of: exist)))
@@ -458,13 +490,21 @@ open class ClaimCoverage: BackboneElement {
 	}
 
 	public dynamic var businessArrangement: String?
+	
 	public dynamic var claimResponse: Reference?
+	
 	public dynamic var coverage: Reference?
+	
 	public let focal = RealmOptional<Bool>()
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public let preAuthRef = RealmSwift.List<RealmString>()
+	
 	public dynamic var relationship: Coding?
+	
 	public let sequence = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -483,6 +523,7 @@ open class ClaimCoverage: BackboneElement {
 				presentKeys.insert("businessArrangement")
 				if let val = exist as? String {
 					self.businessArrangement = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "businessArrangement", wants: String.self, has: type(of: exist)))
@@ -513,6 +554,7 @@ open class ClaimCoverage: BackboneElement {
 				presentKeys.insert("focal")
 				if let val = exist as? Bool {
 					self.focal.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "focal", wants: Bool.self, has: type(of: exist)))
@@ -555,6 +597,7 @@ open class ClaimCoverage: BackboneElement {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -611,7 +654,9 @@ open class ClaimDiagnosis: BackboneElement {
 	}
 
 	public dynamic var diagnosis: Coding?
+	
 	public let sequence = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -640,6 +685,7 @@ open class ClaimDiagnosis: BackboneElement {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -678,22 +724,39 @@ open class ClaimItem: BackboneElement {
 	}
 
 	public dynamic var bodySite: Coding?
+	
 	public let detail = RealmSwift.List<ClaimItemDetail>()
+	
 	public let diagnosisLinkId = RealmSwift.List<RealmInt>()
+	
 	public dynamic var factor: RealmDecimal?
+	
 	public let modifier = RealmSwift.List<Coding>()
+	
 	public dynamic var net: Quantity?
+	
 	public dynamic var points: RealmDecimal?
+	
 	public dynamic var prosthesis: ClaimItemProsthesis?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var quantity: Quantity?
+	
 	public let sequence = RealmOptional<Int>()
+	
 	public dynamic var service: Coding?
+	
 	public dynamic var serviceDate: FHIRDate?
+	
 	public let subSite = RealmSwift.List<Coding>()
+	
 	public dynamic var type: Coding?
+	
 	public dynamic var udi: Coding?
+	
 	public dynamic var unitPrice: Quantity?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -805,6 +868,7 @@ open class ClaimItem: BackboneElement {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -950,15 +1014,25 @@ open class ClaimItemDetail: BackboneElement {
 	}
 
 	public dynamic var factor: RealmDecimal?
+	
 	public dynamic var net: Quantity?
+	
 	public dynamic var points: RealmDecimal?
+	
 	public dynamic var quantity: Quantity?
+	
 	public let sequence = RealmOptional<Int>()
+	
 	public dynamic var service: Coding?
+	
 	public let subDetail = RealmSwift.List<ClaimItemDetailSubDetail>()
+	
 	public dynamic var type: Coding?
+	
 	public dynamic var udi: Coding?
+	
 	public dynamic var unitPrice: Quantity?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1012,6 +1086,7 @@ open class ClaimItemDetail: BackboneElement {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -1127,14 +1202,23 @@ open class ClaimItemDetailSubDetail: BackboneElement {
 	}
 
 	public dynamic var factor: RealmDecimal?
+	
 	public dynamic var net: Quantity?
+	
 	public dynamic var points: RealmDecimal?
+	
 	public dynamic var quantity: Quantity?
+	
 	public let sequence = RealmOptional<Int>()
+	
 	public dynamic var service: Coding?
+	
 	public dynamic var type: Coding?
+	
 	public dynamic var udi: Coding?
+	
 	public dynamic var unitPrice: Quantity?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1188,6 +1272,7 @@ open class ClaimItemDetailSubDetail: BackboneElement {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -1289,8 +1374,11 @@ open class ClaimItemProsthesis: BackboneElement {
 	}
 
 	public let initial = RealmOptional<Bool>()
+	
 	public dynamic var priorDate: FHIRDate?
+	
 	public dynamic var priorMaterial: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1300,6 +1388,7 @@ open class ClaimItemProsthesis: BackboneElement {
 				presentKeys.insert("initial")
 				if let val = exist as? Bool {
 					self.initial.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "initial", wants: Bool.self, has: type(of: exist)))
@@ -1357,8 +1446,11 @@ open class ClaimMissingTeeth: BackboneElement {
 	}
 
 	public dynamic var extractionDate: FHIRDate?
+	
 	public dynamic var reason: Coding?
+	
 	public dynamic var tooth: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1433,9 +1525,13 @@ open class ClaimPayee: BackboneElement {
 	}
 
 	public dynamic var organization: Reference?
+	
 	public dynamic var person: Reference?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ClaimResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ClaimResponse.swift
@@ -2,7 +2,7 @@
 //  ClaimResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClaimResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClaimResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,31 +21,57 @@ open class ClaimResponse: DomainResource {
 	}
 
 	public let addItem = RealmSwift.List<ClaimResponseAddItem>()
+	
 	public let coverage = RealmSwift.List<ClaimResponseCoverage>()
+	
 	public dynamic var created: DateTime?
+	
 	public dynamic var disposition: String?
+	
 	public let error = RealmSwift.List<ClaimResponseError>()
+	
 	public dynamic var form: Coding?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let item = RealmSwift.List<ClaimResponseItem>()
+	
 	public let note = RealmSwift.List<ClaimResponseNote>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var outcome: String?
+	
 	public dynamic var payeeType: Coding?
+	
 	public dynamic var paymentAdjustment: Quantity?
+	
 	public dynamic var paymentAdjustmentReason: Coding?
+	
 	public dynamic var paymentAmount: Quantity?
+	
 	public dynamic var paymentDate: FHIRDate?
+	
 	public dynamic var paymentRef: Identifier?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var requestOrganization: Reference?
+	
 	public dynamic var requestProvider: Reference?
+	
 	public dynamic var reserved: Coding?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var totalBenefit: Quantity?
+	
 	public dynamic var totalCost: Quantity?
+	
 	public dynamic var unallocDeductable: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -86,6 +112,7 @@ open class ClaimResponse: DomainResource {
 				presentKeys.insert("disposition")
 				if let val = exist as? String {
 					self.disposition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "disposition", wants: String.self, has: type(of: exist)))
@@ -166,6 +193,7 @@ open class ClaimResponse: DomainResource {
 				presentKeys.insert("outcome")
 				if let val = exist as? String {
 					self.outcome = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcome", wants: String.self, has: type(of: exist)))
@@ -399,11 +427,17 @@ open class ClaimResponseAddItem: BackboneElement {
 	}
 
 	public let adjudication = RealmSwift.List<ClaimResponseAddItemAdjudication>()
+	
 	public let detail = RealmSwift.List<ClaimResponseAddItemDetail>()
+	
 	public dynamic var fee: Quantity?
+	
 	public let noteNumberLinkId = RealmSwift.List<RealmInt>()
+	
 	public let sequenceLinkId = RealmSwift.List<RealmInt>()
+	
 	public dynamic var service: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -518,8 +552,11 @@ open class ClaimResponseAddItemAdjudication: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var code: Coding?
+	
 	public dynamic var value: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -594,8 +631,11 @@ open class ClaimResponseAddItemDetail: BackboneElement {
 	}
 
 	public let adjudication = RealmSwift.List<ClaimResponseAddItemDetailAdjudication>()
+	
 	public dynamic var fee: Quantity?
+	
 	public dynamic var service: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -672,8 +712,11 @@ open class ClaimResponseAddItemDetailAdjudication: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var code: Coding?
+	
 	public dynamic var value: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -748,13 +791,21 @@ open class ClaimResponseCoverage: BackboneElement {
 	}
 
 	public dynamic var businessArrangement: String?
+	
 	public dynamic var claimResponse: Reference?
+	
 	public dynamic var coverage: Reference?
+	
 	public let focal = RealmOptional<Bool>()
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public let preAuthRef = RealmSwift.List<RealmString>()
+	
 	public dynamic var relationship: Coding?
+	
 	public let sequence = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -773,6 +824,7 @@ open class ClaimResponseCoverage: BackboneElement {
 				presentKeys.insert("businessArrangement")
 				if let val = exist as? String {
 					self.businessArrangement = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "businessArrangement", wants: String.self, has: type(of: exist)))
@@ -803,6 +855,7 @@ open class ClaimResponseCoverage: BackboneElement {
 				presentKeys.insert("focal")
 				if let val = exist as? Bool {
 					self.focal.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "focal", wants: Bool.self, has: type(of: exist)))
@@ -845,6 +898,7 @@ open class ClaimResponseCoverage: BackboneElement {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -901,9 +955,13 @@ open class ClaimResponseError: BackboneElement {
 	}
 
 	public dynamic var code: Coding?
+	
 	public let detailSequenceLinkId = RealmOptional<Int>()
+	
 	public let sequenceLinkId = RealmOptional<Int>()
+	
 	public let subdetailSequenceLinkId = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -931,6 +989,7 @@ open class ClaimResponseError: BackboneElement {
 				presentKeys.insert("detailSequenceLinkId")
 				if let val = exist as? Int {
 					self.detailSequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "detailSequenceLinkId", wants: Int.self, has: type(of: exist)))
@@ -940,6 +999,7 @@ open class ClaimResponseError: BackboneElement {
 				presentKeys.insert("sequenceLinkId")
 				if let val = exist as? Int {
 					self.sequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequenceLinkId", wants: Int.self, has: type(of: exist)))
@@ -949,6 +1009,7 @@ open class ClaimResponseError: BackboneElement {
 				presentKeys.insert("subdetailSequenceLinkId")
 				if let val = exist as? Int {
 					self.subdetailSequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "subdetailSequenceLinkId", wants: Int.self, has: type(of: exist)))
@@ -990,9 +1051,13 @@ open class ClaimResponseItem: BackboneElement {
 	}
 
 	public let adjudication = RealmSwift.List<ClaimResponseItemAdjudication>()
+	
 	public let detail = RealmSwift.List<ClaimResponseItemDetail>()
+	
 	public let noteNumber = RealmSwift.List<RealmInt>()
+	
 	public let sequenceLinkId = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1039,6 +1104,7 @@ open class ClaimResponseItem: BackboneElement {
 				presentKeys.insert("sequenceLinkId")
 				if let val = exist as? Int {
 					self.sequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequenceLinkId", wants: Int.self, has: type(of: exist)))
@@ -1083,8 +1149,11 @@ open class ClaimResponseItemAdjudication: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var code: Coding?
+	
 	public dynamic var value: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1159,8 +1228,11 @@ open class ClaimResponseItemDetail: BackboneElement {
 	}
 
 	public let adjudication = RealmSwift.List<ClaimResponseItemDetailAdjudication>()
+	
 	public let sequenceLinkId = RealmOptional<Int>()
+	
 	public let subDetail = RealmSwift.List<ClaimResponseItemDetailSubDetail>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1187,6 +1259,7 @@ open class ClaimResponseItemDetail: BackboneElement {
 				presentKeys.insert("sequenceLinkId")
 				if let val = exist as? Int {
 					self.sequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequenceLinkId", wants: Int.self, has: type(of: exist)))
@@ -1239,8 +1312,11 @@ open class ClaimResponseItemDetailAdjudication: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var code: Coding?
+	
 	public dynamic var value: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1315,7 +1391,9 @@ open class ClaimResponseItemDetailSubDetail: BackboneElement {
 	}
 
 	public let adjudication = RealmSwift.List<ClaimResponseItemDetailSubDetailAdjudication>()
+	
 	public let sequenceLinkId = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1342,6 +1420,7 @@ open class ClaimResponseItemDetailSubDetail: BackboneElement {
 				presentKeys.insert("sequenceLinkId")
 				if let val = exist as? Int {
 					self.sequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequenceLinkId", wants: Int.self, has: type(of: exist)))
@@ -1380,8 +1459,11 @@ open class ClaimResponseItemDetailSubDetailAdjudication: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var code: Coding?
+	
 	public dynamic var value: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1456,8 +1538,11 @@ open class ClaimResponseNote: BackboneElement {
 	}
 
 	public let number = RealmOptional<Int>()
+	
 	public dynamic var text: String?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1467,6 +1552,7 @@ open class ClaimResponseNote: BackboneElement {
 				presentKeys.insert("number")
 				if let val = exist as? Int {
 					self.number.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "number", wants: Int.self, has: type(of: exist)))
@@ -1476,6 +1562,7 @@ open class ClaimResponseNote: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ClinicalImpression.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ClinicalImpression.swift
@@ -2,7 +2,7 @@
 //  ClinicalImpression.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClinicalImpression) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClinicalImpression) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -25,23 +25,41 @@ open class ClinicalImpression: DomainResource {
 	}
 
 	public let action = RealmSwift.List<Reference>()
+	
 	public dynamic var assessor: Reference?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let finding = RealmSwift.List<ClinicalImpressionFinding>()
+	
 	public let investigations = RealmSwift.List<ClinicalImpressionInvestigations>()
+	
 	public dynamic var patient: Reference?
+	
 	public let plan = RealmSwift.List<Reference>()
+	
 	public dynamic var previous: Reference?
+	
 	public let problem = RealmSwift.List<Reference>()
+	
 	public dynamic var prognosis: String?
+	
 	public dynamic var protocol_fhir: String?
+	
 	public let resolved = RealmSwift.List<CodeableConcept>()
+	
 	public let ruledOut = RealmSwift.List<ClinicalImpressionRuledOut>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var summary: String?
+	
 	public dynamic var triggerCodeableConcept: CodeableConcept?
+	
 	public dynamic var triggerReference: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -87,6 +105,7 @@ open class ClinicalImpression: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -161,6 +180,7 @@ open class ClinicalImpression: DomainResource {
 				presentKeys.insert("prognosis")
 				if let val = exist as? String {
 					self.prognosis = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "prognosis", wants: String.self, has: type(of: exist)))
@@ -170,6 +190,7 @@ open class ClinicalImpression: DomainResource {
 				presentKeys.insert("protocol")
 				if let val = exist as? String {
 					self.protocol_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "protocol", wants: String.self, has: type(of: exist)))
@@ -201,6 +222,7 @@ open class ClinicalImpression: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -213,6 +235,7 @@ open class ClinicalImpression: DomainResource {
 				presentKeys.insert("summary")
 				if let val = exist as? String {
 					self.summary = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "summary", wants: String.self, has: type(of: exist)))
@@ -314,7 +337,9 @@ open class ClinicalImpressionFinding: BackboneElement {
 	}
 
 	public dynamic var cause: String?
+	
 	public dynamic var item: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -330,6 +355,7 @@ open class ClinicalImpressionFinding: BackboneElement {
 				presentKeys.insert("cause")
 				if let val = exist as? String {
 					self.cause = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "cause", wants: String.self, has: type(of: exist)))
@@ -379,7 +405,9 @@ open class ClinicalImpressionInvestigations: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public let item = RealmSwift.List<Reference>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -442,7 +470,9 @@ open class ClinicalImpressionRuledOut: BackboneElement {
 	}
 
 	public dynamic var item: CodeableConcept?
+	
 	public dynamic var reason: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -470,6 +500,7 @@ open class ClinicalImpressionRuledOut: BackboneElement {
 				presentKeys.insert("reason")
 				if let val = exist as? String {
 					self.reason = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reason", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/CodeableConcept.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/CodeableConcept.swift
@@ -2,7 +2,7 @@
 //  CodeableConcept.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CodeableConcept) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CodeableConcept) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,7 +21,9 @@ open class CodeableConcept: Element {
 	}
 
 	public let coding = RealmSwift.List<Coding>()
+	
 	public dynamic var text: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -42,6 +44,7 @@ open class CodeableConcept: Element {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Coding.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Coding.swift
@@ -2,7 +2,7 @@
 //  Coding.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coding) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coding) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,10 +19,15 @@ open class Coding: Element {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var display: String?
+	
 	public dynamic var system: String?
+	
 	public let userSelected = RealmOptional<Bool>()
+	
 	public dynamic var version: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -32,6 +37,7 @@ open class Coding: Element {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -41,6 +47,7 @@ open class Coding: Element {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -50,6 +57,7 @@ open class Coding: Element {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -59,6 +67,7 @@ open class Coding: Element {
 				presentKeys.insert("userSelected")
 				if let val = exist as? Bool {
 					self.userSelected.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "userSelected", wants: Bool.self, has: type(of: exist)))
@@ -68,6 +77,7 @@ open class Coding: Element {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Communication.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Communication.swift
@@ -2,7 +2,7 @@
 //  Communication.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Communication) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Communication) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,18 +22,31 @@ open class Communication: DomainResource {
 	}
 
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let medium = RealmSwift.List<CodeableConcept>()
+	
 	public let payload = RealmSwift.List<CommunicationPayload>()
+	
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var received: DateTime?
+	
 	public let recipient = RealmSwift.List<Reference>()
+	
 	public dynamic var requestDetail: Reference?
+	
 	public dynamic var sender: Reference?
+	
 	public dynamic var sent: DateTime?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -152,6 +165,7 @@ open class Communication: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -229,8 +243,11 @@ open class CommunicationPayload: BackboneElement {
 	}
 
 	public dynamic var contentAttachment: Attachment?
+	
 	public dynamic var contentReference: Reference?
+	
 	public dynamic var contentString: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -266,6 +283,7 @@ open class CommunicationPayload: BackboneElement {
 				presentKeys.insert("contentString")
 				if let val = exist as? String {
 					self.contentString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentString", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/CommunicationRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/CommunicationRequest.swift
@@ -2,7 +2,7 @@
 //  CommunicationRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CommunicationRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CommunicationRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,20 +22,35 @@ open class CommunicationRequest: DomainResource {
 	}
 
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let medium = RealmSwift.List<CodeableConcept>()
+	
 	public let payload = RealmSwift.List<CommunicationRequestPayload>()
+	
 	public dynamic var priority: CodeableConcept?
+	
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public let recipient = RealmSwift.List<Reference>()
+	
 	public dynamic var requestedOn: DateTime?
+	
 	public dynamic var requester: Reference?
+	
 	public dynamic var scheduledDateTime: DateTime?
+	
 	public dynamic var scheduledPeriod: Period?
+	
 	public dynamic var sender: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -172,6 +187,7 @@ open class CommunicationRequest: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -255,8 +271,11 @@ open class CommunicationRequestPayload: BackboneElement {
 	}
 
 	public dynamic var contentAttachment: Attachment?
+	
 	public dynamic var contentReference: Reference?
+	
 	public dynamic var contentString: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -292,6 +311,7 @@ open class CommunicationRequestPayload: BackboneElement {
 				presentKeys.insert("contentString")
 				if let val = exist as? String {
 					self.contentString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentString", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Composition.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Composition.swift
@@ -2,7 +2,7 @@
 //  Composition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Composition) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Composition) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -25,19 +25,33 @@ open class Composition: DomainResource {
 	}
 
 	public let attester = RealmSwift.List<CompositionAttester>()
+	
 	public let author = RealmSwift.List<Reference>()
+	
 	public dynamic var class_fhir: CodeableConcept?
+	
 	public dynamic var confidentiality: String?
+	
 	public dynamic var custodian: Reference?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var encounter: Reference?
+	
 	public let event = RealmSwift.List<CompositionEvent>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public let section = RealmSwift.List<CompositionSection>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var title: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -92,6 +106,7 @@ open class Composition: DomainResource {
 				presentKeys.insert("confidentiality")
 				if let val = exist as? String {
 					self.confidentiality = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "confidentiality", wants: String.self, has: type(of: exist)))
@@ -162,6 +177,7 @@ open class Composition: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -186,6 +202,7 @@ open class Composition: DomainResource {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))
@@ -272,8 +289,11 @@ open class CompositionAttester: BackboneElement {
 	}
 
 	public let mode = RealmSwift.List<RealmString>()
+	
 	public dynamic var party: Reference?
+	
 	public dynamic var time: DateTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -348,8 +368,11 @@ open class CompositionEvent: BackboneElement {
 	}
 
 	public let code = RealmSwift.List<CodeableConcept>()
+	
 	public let detail = RealmSwift.List<Reference>()
+	
 	public dynamic var period: Period?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -419,13 +442,21 @@ open class CompositionSection: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var emptyReason: CodeableConcept?
+	
 	public let entry = RealmSwift.List<Reference>()
+	
 	public dynamic var mode: String?
+	
 	public dynamic var orderedBy: CodeableConcept?
+	
 	public let section = RealmSwift.List<CompositionSection>()
+	
 	public dynamic var text: Narrative?
+	
 	public dynamic var title: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -464,6 +495,7 @@ open class CompositionSection: BackboneElement {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -502,6 +534,7 @@ open class CompositionSection: BackboneElement {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ConceptMap.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ConceptMap.swift
@@ -2,7 +2,7 @@
 //  ConceptMap.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ConceptMap) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ConceptMap) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,23 +22,41 @@ open class ConceptMap: DomainResource {
 	}
 
 	public let contact = RealmSwift.List<ConceptMapContact>()
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let element = RealmSwift.List<ConceptMapElement>()
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var name: String?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var sourceReference: Reference?
+	
 	public dynamic var sourceUri: String?
+	
 	public dynamic var status: String?
+	
 	public dynamic var targetReference: Reference?
+	
 	public dynamic var targetUri: String?
+	
 	public dynamic var url: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -69,6 +87,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -87,6 +106,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -107,6 +127,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -125,6 +146,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -134,6 +156,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -143,6 +166,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -161,6 +185,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("sourceUri")
 				if let val = exist as? String {
 					self.sourceUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sourceUri", wants: String.self, has: type(of: exist)))
@@ -170,6 +195,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -191,6 +217,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("targetUri")
 				if let val = exist as? String {
 					self.targetUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "targetUri", wants: String.self, has: type(of: exist)))
@@ -200,6 +227,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -220,6 +248,7 @@ open class ConceptMap: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -311,7 +340,9 @@ open class ConceptMapContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -321,6 +352,7 @@ open class ConceptMapContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -367,8 +399,11 @@ open class ConceptMapElement: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var codeSystem: String?
+	
 	public let target = RealmSwift.List<ConceptMapElementTarget>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -378,6 +413,7 @@ open class ConceptMapElement: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -387,6 +423,7 @@ open class ConceptMapElement: BackboneElement {
 				presentKeys.insert("codeSystem")
 				if let val = exist as? String {
 					self.codeSystem = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "codeSystem", wants: String.self, has: type(of: exist)))
@@ -436,11 +473,17 @@ open class ConceptMapElementTarget: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var codeSystem: String?
+	
 	public dynamic var comments: String?
+	
 	public let dependsOn = RealmSwift.List<ConceptMapElementTargetDependsOn>()
+	
 	public dynamic var equivalence: String?
+	
 	public let product = RealmSwift.List<ConceptMapElementTargetDependsOn>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -456,6 +499,7 @@ open class ConceptMapElementTarget: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -465,6 +509,7 @@ open class ConceptMapElementTarget: BackboneElement {
 				presentKeys.insert("codeSystem")
 				if let val = exist as? String {
 					self.codeSystem = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "codeSystem", wants: String.self, has: type(of: exist)))
@@ -474,6 +519,7 @@ open class ConceptMapElementTarget: BackboneElement {
 				presentKeys.insert("comments")
 				if let val = exist as? String {
 					self.comments = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comments", wants: String.self, has: type(of: exist)))
@@ -494,6 +540,7 @@ open class ConceptMapElementTarget: BackboneElement {
 				presentKeys.insert("equivalence")
 				if let val = exist as? String {
 					self.equivalence = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "equivalence", wants: String.self, has: type(of: exist)))
@@ -556,8 +603,11 @@ open class ConceptMapElementTargetDependsOn: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var codeSystem: String?
+	
 	public dynamic var element: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -575,6 +625,7 @@ open class ConceptMapElementTargetDependsOn: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -587,6 +638,7 @@ open class ConceptMapElementTargetDependsOn: BackboneElement {
 				presentKeys.insert("codeSystem")
 				if let val = exist as? String {
 					self.codeSystem = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "codeSystem", wants: String.self, has: type(of: exist)))
@@ -599,6 +651,7 @@ open class ConceptMapElementTargetDependsOn: BackboneElement {
 				presentKeys.insert("element")
 				if let val = exist as? String {
 					self.element = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "element", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Condition.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Condition.swift
@@ -2,7 +2,7 @@
 //  Condition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Condition) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Condition) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,30 +23,55 @@ open class Condition: DomainResource {
 	}
 
 	public let abatementBoolean = RealmOptional<Bool>()
+	
 	public dynamic var abatementDateTime: DateTime?
+	
 	public dynamic var abatementPeriod: Period?
+	
 	public dynamic var abatementQuantity: Quantity?
+	
 	public dynamic var abatementRange: Range?
+	
 	public dynamic var abatementString: String?
+	
 	public dynamic var asserter: Reference?
+	
 	public let bodySite = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var clinicalStatus: String?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var dateRecorded: FHIRDate?
+	
 	public dynamic var encounter: Reference?
+	
 	public let evidence = RealmSwift.List<ConditionEvidence>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var notes: String?
+	
 	public dynamic var onsetDateTime: DateTime?
+	
 	public dynamic var onsetPeriod: Period?
+	
 	public dynamic var onsetQuantity: Quantity?
+	
 	public dynamic var onsetRange: Range?
+	
 	public dynamic var onsetString: String?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var severity: CodeableConcept?
+	
 	public dynamic var stage: ConditionStage?
+	
 	public dynamic var verificationStatus: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -64,6 +89,7 @@ open class Condition: DomainResource {
 				presentKeys.insert("abatementBoolean")
 				if let val = exist as? Bool {
 					self.abatementBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "abatementBoolean", wants: Bool.self, has: type(of: exist)))
@@ -109,6 +135,7 @@ open class Condition: DomainResource {
 				presentKeys.insert("abatementString")
 				if let val = exist as? String {
 					self.abatementString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "abatementString", wants: String.self, has: type(of: exist)))
@@ -147,6 +174,7 @@ open class Condition: DomainResource {
 				presentKeys.insert("clinicalStatus")
 				if let val = exist as? String {
 					self.clinicalStatus = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "clinicalStatus", wants: String.self, has: type(of: exist)))
@@ -208,6 +236,7 @@ open class Condition: DomainResource {
 				presentKeys.insert("notes")
 				if let val = exist as? String {
 					self.notes = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "notes", wants: String.self, has: type(of: exist)))
@@ -253,6 +282,7 @@ open class Condition: DomainResource {
 				presentKeys.insert("onsetString")
 				if let val = exist as? String {
 					self.onsetString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "onsetString", wants: String.self, has: type(of: exist)))
@@ -292,6 +322,7 @@ open class Condition: DomainResource {
 				presentKeys.insert("verificationStatus")
 				if let val = exist as? String {
 					self.verificationStatus = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "verificationStatus", wants: String.self, has: type(of: exist)))
@@ -399,7 +430,9 @@ open class ConditionEvidence: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public let detail = RealmSwift.List<Reference>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -455,7 +488,9 @@ open class ConditionStage: BackboneElement {
 	}
 
 	public let assessment = RealmSwift.List<Reference>()
+	
 	public dynamic var summary: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Conformance.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Conformance.swift
@@ -2,7 +2,7 @@
 //  Conformance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Conformance) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Conformance) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,26 +22,47 @@ open class Conformance: DomainResource {
 	}
 
 	public dynamic var acceptUnknown: String?
+	
 	public let contact = RealmSwift.List<ConformanceContact>()
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let document = RealmSwift.List<ConformanceDocument>()
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public dynamic var fhirVersion: String?
+	
 	public let format = RealmSwift.List<RealmString>()
+	
 	public dynamic var implementation: ConformanceImplementation?
+	
 	public dynamic var kind: String?
+	
 	public let messaging = RealmSwift.List<ConformanceMessaging>()
+	
 	public dynamic var name: String?
+	
 	public let profile = RealmSwift.List<Reference>()
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public let rest = RealmSwift.List<ConformanceRest>()
+	
 	public dynamic var software: ConformanceSoftware?
+	
 	public dynamic var status: String?
+	
 	public dynamic var url: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -61,6 +82,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("acceptUnknown")
 				if let val = exist as? String {
 					self.acceptUnknown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "acceptUnknown", wants: String.self, has: type(of: exist)))
@@ -84,6 +106,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -105,6 +128,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -125,6 +149,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -134,6 +159,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("fhirVersion")
 				if let val = exist as? String {
 					self.fhirVersion = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fhirVersion", wants: String.self, has: type(of: exist)))
@@ -167,6 +193,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("kind")
 				if let val = exist as? String {
 					self.kind = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "kind", wants: String.self, has: type(of: exist)))
@@ -190,6 +217,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -210,6 +238,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -219,6 +248,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -248,6 +278,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -257,6 +288,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -266,6 +298,7 @@ open class Conformance: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -358,7 +391,9 @@ open class ConformanceContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -368,6 +403,7 @@ open class ConformanceContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -414,8 +450,11 @@ open class ConformanceDocument: BackboneElement {
 	}
 
 	public dynamic var documentation: String?
+	
 	public dynamic var mode: String?
+	
 	public dynamic var profile: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -432,6 +471,7 @@ open class ConformanceDocument: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -441,6 +481,7 @@ open class ConformanceDocument: BackboneElement {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -495,7 +536,9 @@ open class ConformanceImplementation: BackboneElement {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -511,6 +554,7 @@ open class ConformanceImplementation: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -523,6 +567,7 @@ open class ConformanceImplementation: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -558,9 +603,13 @@ open class ConformanceMessaging: BackboneElement {
 	}
 
 	public dynamic var documentation: String?
+	
 	public let endpoint = RealmSwift.List<ConformanceMessagingEndpoint>()
+	
 	public let event = RealmSwift.List<ConformanceMessagingEvent>()
+	
 	public let reliableCache = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -576,6 +625,7 @@ open class ConformanceMessaging: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -610,6 +660,7 @@ open class ConformanceMessaging: BackboneElement {
 				presentKeys.insert("reliableCache")
 				if let val = exist as? Int {
 					self.reliableCache.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reliableCache", wants: Int.self, has: type(of: exist)))
@@ -651,7 +702,9 @@ open class ConformanceMessagingEndpoint: BackboneElement {
 	}
 
 	public dynamic var address: String?
+	
 	public dynamic var protocol_fhir: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -668,6 +721,7 @@ open class ConformanceMessagingEndpoint: BackboneElement {
 				presentKeys.insert("address")
 				if let val = exist as? String {
 					self.address = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "address", wants: String.self, has: type(of: exist)))
@@ -718,12 +772,19 @@ open class ConformanceMessagingEvent: BackboneElement {
 	}
 
 	public dynamic var category: String?
+	
 	public dynamic var code: Coding?
+	
 	public dynamic var documentation: String?
+	
 	public dynamic var focus: String?
+	
 	public dynamic var mode: String?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var response: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -743,6 +804,7 @@ open class ConformanceMessagingEvent: BackboneElement {
 				presentKeys.insert("category")
 				if let val = exist as? String {
 					self.category = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "category", wants: String.self, has: type(of: exist)))
@@ -764,6 +826,7 @@ open class ConformanceMessagingEvent: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -773,6 +836,7 @@ open class ConformanceMessagingEvent: BackboneElement {
 				presentKeys.insert("focus")
 				if let val = exist as? String {
 					self.focus = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "focus", wants: String.self, has: type(of: exist)))
@@ -785,6 +849,7 @@ open class ConformanceMessagingEvent: BackboneElement {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -862,14 +927,23 @@ open class ConformanceRest: BackboneElement {
 	}
 
 	public let compartment = RealmSwift.List<RealmString>()
+	
 	public dynamic var documentation: String?
+	
 	public let interaction = RealmSwift.List<ConformanceRestInteraction>()
+	
 	public dynamic var mode: String?
+	
 	public let operation = RealmSwift.List<ConformanceRestOperation>()
+	
 	public let resource = RealmSwift.List<ConformanceRestResource>()
+	
 	public let searchParam = RealmSwift.List<ConformanceRestResourceSearchParam>()
+	
 	public dynamic var security: ConformanceRestSecurity?
+	
 	public dynamic var transactionMode: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -895,6 +969,7 @@ open class ConformanceRest: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -915,6 +990,7 @@ open class ConformanceRest: BackboneElement {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -972,6 +1048,7 @@ open class ConformanceRest: BackboneElement {
 				presentKeys.insert("transactionMode")
 				if let val = exist as? String {
 					self.transactionMode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "transactionMode", wants: String.self, has: type(of: exist)))
@@ -1028,7 +1105,9 @@ open class ConformanceRestInteraction: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var documentation: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1044,6 +1123,7 @@ open class ConformanceRestInteraction: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -1056,6 +1136,7 @@ open class ConformanceRestInteraction: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -1091,7 +1172,9 @@ open class ConformanceRestOperation: BackboneElement {
 	}
 
 	public dynamic var definition: Reference?
+	
 	public dynamic var name: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1120,6 +1203,7 @@ open class ConformanceRestOperation: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1158,17 +1242,29 @@ open class ConformanceRestResource: BackboneElement {
 	}
 
 	public let conditionalCreate = RealmOptional<Bool>()
+	
 	public dynamic var conditionalDelete: String?
+	
 	public let conditionalUpdate = RealmOptional<Bool>()
+	
 	public let interaction = RealmSwift.List<ConformanceRestResourceInteraction>()
+	
 	public dynamic var profile: Reference?
+	
 	public let readHistory = RealmOptional<Bool>()
+	
 	public let searchInclude = RealmSwift.List<RealmString>()
+	
 	public let searchParam = RealmSwift.List<ConformanceRestResourceSearchParam>()
+	
 	public let searchRevInclude = RealmSwift.List<RealmString>()
+	
 	public dynamic var type: String?
+	
 	public let updateCreate = RealmOptional<Bool>()
+	
 	public dynamic var versioning: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1185,6 +1281,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("conditionalCreate")
 				if let val = exist as? Bool {
 					self.conditionalCreate.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "conditionalCreate", wants: Bool.self, has: type(of: exist)))
@@ -1194,6 +1291,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("conditionalDelete")
 				if let val = exist as? String {
 					self.conditionalDelete = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "conditionalDelete", wants: String.self, has: type(of: exist)))
@@ -1203,6 +1301,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("conditionalUpdate")
 				if let val = exist as? Bool {
 					self.conditionalUpdate.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "conditionalUpdate", wants: Bool.self, has: type(of: exist)))
@@ -1235,6 +1334,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("readHistory")
 				if let val = exist as? Bool {
 					self.readHistory.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "readHistory", wants: Bool.self, has: type(of: exist)))
@@ -1273,6 +1373,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -1285,6 +1386,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("updateCreate")
 				if let val = exist as? Bool {
 					self.updateCreate.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "updateCreate", wants: Bool.self, has: type(of: exist)))
@@ -1294,6 +1396,7 @@ open class ConformanceRestResource: BackboneElement {
 				presentKeys.insert("versioning")
 				if let val = exist as? String {
 					self.versioning = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "versioning", wants: String.self, has: type(of: exist)))
@@ -1359,7 +1462,9 @@ open class ConformanceRestResourceInteraction: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var documentation: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1375,6 +1480,7 @@ open class ConformanceRestResourceInteraction: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -1387,6 +1493,7 @@ open class ConformanceRestResourceInteraction: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -1423,12 +1530,19 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 	}
 
 	public let chain = RealmSwift.List<RealmString>()
+	
 	public dynamic var definition: String?
+	
 	public dynamic var documentation: String?
+	
 	public let modifier = RealmSwift.List<RealmString>()
+	
 	public dynamic var name: String?
+	
 	public let target = RealmSwift.List<RealmString>()
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1454,6 +1568,7 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 				presentKeys.insert("definition")
 				if let val = exist as? String {
 					self.definition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "definition", wants: String.self, has: type(of: exist)))
@@ -1463,6 +1578,7 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -1481,6 +1597,7 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1502,6 +1619,7 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -1555,9 +1673,13 @@ open class ConformanceRestSecurity: BackboneElement {
 	}
 
 	public let certificate = RealmSwift.List<ConformanceRestSecurityCertificate>()
+	
 	public let cors = RealmOptional<Bool>()
+	
 	public dynamic var description_fhir: String?
+	
 	public let service = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1578,6 +1700,7 @@ open class ConformanceRestSecurity: BackboneElement {
 				presentKeys.insert("cors")
 				if let val = exist as? Bool {
 					self.cors.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "cors", wants: Bool.self, has: type(of: exist)))
@@ -1587,6 +1710,7 @@ open class ConformanceRestSecurity: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -1637,7 +1761,9 @@ open class ConformanceRestSecurityCertificate: BackboneElement {
 	}
 
 	public dynamic var blob: Base64Binary?
+	
 	public dynamic var type: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1656,6 +1782,7 @@ open class ConformanceRestSecurityCertificate: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -1692,8 +1819,11 @@ open class ConformanceSoftware: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public dynamic var releaseDate: DateTime?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1709,6 +1839,7 @@ open class ConformanceSoftware: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1730,6 +1861,7 @@ open class ConformanceSoftware: BackboneElement {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ContactPoint.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ContactPoint.swift
@@ -2,7 +2,7 @@
 //  ContactPoint.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ContactPoint) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ContactPoint) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,10 +22,15 @@ open class ContactPoint: Element {
 	}
 
 	public dynamic var period: Period?
+	
 	public let rank = RealmOptional<Int>()
+	
 	public dynamic var system: String?
+	
 	public dynamic var use: String?
+	
 	public dynamic var value: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -44,6 +49,7 @@ open class ContactPoint: Element {
 				presentKeys.insert("rank")
 				if let val = exist as? Int {
 					self.rank.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "rank", wants: Int.self, has: type(of: exist)))
@@ -53,6 +59,7 @@ open class ContactPoint: Element {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -62,6 +69,7 @@ open class ContactPoint: Element {
 				presentKeys.insert("use")
 				if let val = exist as? String {
 					self.use = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "use", wants: String.self, has: type(of: exist)))
@@ -71,6 +79,7 @@ open class ContactPoint: Element {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Contract.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Contract.swift
@@ -2,7 +2,7 @@
 //  Contract.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Contract) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Contract) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,24 +21,43 @@ open class Contract: DomainResource {
 	}
 
 	public let action = RealmSwift.List<CodeableConcept>()
+	
 	public let actionReason = RealmSwift.List<CodeableConcept>()
+	
 	public let actor = RealmSwift.List<ContractActor>()
+	
 	public dynamic var applies: Period?
+	
 	public let authority = RealmSwift.List<Reference>()
+	
 	public dynamic var bindingAttachment: Attachment?
+	
 	public dynamic var bindingReference: Reference?
+	
 	public let domain = RealmSwift.List<Reference>()
+	
 	public let friendly = RealmSwift.List<ContractFriendly>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var issued: DateTime?
+	
 	public let legal = RealmSwift.List<ContractLegal>()
+	
 	public let rule = RealmSwift.List<ContractRule>()
+	
 	public let signer = RealmSwift.List<ContractSigner>()
+	
 	public let subType = RealmSwift.List<CodeableConcept>()
+	
 	public let subject = RealmSwift.List<Reference>()
+	
 	public let term = RealmSwift.List<ContractTerm>()
+	
 	public dynamic var type: CodeableConcept?
+	
 	public let valuedItem = RealmSwift.List<ContractValuedItem>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -322,7 +341,9 @@ open class ContractActor: BackboneElement {
 	}
 
 	public dynamic var entity: Reference?
+	
 	public let role = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -390,7 +411,9 @@ open class ContractFriendly: BackboneElement {
 	}
 
 	public dynamic var contentAttachment: Attachment?
+	
 	public dynamic var contentReference: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -456,7 +479,9 @@ open class ContractLegal: BackboneElement {
 	}
 
 	public dynamic var contentAttachment: Attachment?
+	
 	public dynamic var contentReference: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -522,7 +547,9 @@ open class ContractRule: BackboneElement {
 	}
 
 	public dynamic var contentAttachment: Attachment?
+	
 	public dynamic var contentReference: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -588,8 +615,11 @@ open class ContractSigner: BackboneElement {
 	}
 
 	public dynamic var party: Reference?
+	
 	public dynamic var signature: String?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -619,6 +649,7 @@ open class ContractSigner: BackboneElement {
 				presentKeys.insert("signature")
 				if let val = exist as? String {
 					self.signature = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "signature", wants: String.self, has: type(of: exist)))
@@ -672,17 +703,29 @@ open class ContractTerm: BackboneElement {
 	}
 
 	public let action = RealmSwift.List<CodeableConcept>()
+	
 	public let actionReason = RealmSwift.List<CodeableConcept>()
+	
 	public let actor = RealmSwift.List<ContractTermActor>()
+	
 	public dynamic var applies: Period?
+	
 	public let group = RealmSwift.List<ContractTerm>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var issued: DateTime?
+	
 	public dynamic var subType: CodeableConcept?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var text: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public let valuedItem = RealmSwift.List<ContractTermValuedItem>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -781,6 +824,7 @@ open class ContractTerm: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -866,7 +910,9 @@ open class ContractTermActor: BackboneElement {
 	}
 
 	public dynamic var entity: Reference?
+	
 	public let role = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -931,14 +977,23 @@ open class ContractTermValuedItem: BackboneElement {
 	}
 
 	public dynamic var effectiveTime: DateTime?
+	
 	public dynamic var entityCodeableConcept: CodeableConcept?
+	
 	public dynamic var entityReference: Reference?
+	
 	public dynamic var factor: RealmDecimal?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var net: Quantity?
+	
 	public dynamic var points: RealmDecimal?
+	
 	public dynamic var quantity: Quantity?
+	
 	public dynamic var unitPrice: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1076,14 +1131,23 @@ open class ContractValuedItem: BackboneElement {
 	}
 
 	public dynamic var effectiveTime: DateTime?
+	
 	public dynamic var entityCodeableConcept: CodeableConcept?
+	
 	public dynamic var entityReference: Reference?
+	
 	public dynamic var factor: RealmDecimal?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var net: Quantity?
+	
 	public dynamic var points: RealmDecimal?
+	
 	public dynamic var quantity: Quantity?
+	
 	public dynamic var unitPrice: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Count.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Count.swift
@@ -2,7 +2,7 @@
 //  Count.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Count) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Count) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Coverage.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Coverage.swift
@@ -2,7 +2,7 @@
 //  Coverage.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coverage) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coverage) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,19 +21,33 @@ open class Coverage: DomainResource {
 	}
 
 	public dynamic var bin: Identifier?
+	
 	public let contract = RealmSwift.List<Reference>()
+	
 	public let dependent = RealmOptional<Int>()
+	
 	public dynamic var group: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var issuer: Reference?
+	
 	public dynamic var network: Identifier?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var plan: String?
+	
 	public let sequence = RealmOptional<Int>()
+	
 	public dynamic var subPlan: String?
+	
 	public dynamic var subscriber: Reference?
+	
 	public dynamic var subscriberId: Identifier?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -63,6 +77,7 @@ open class Coverage: DomainResource {
 				presentKeys.insert("dependent")
 				if let val = exist as? Int {
 					self.dependent.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "dependent", wants: Int.self, has: type(of: exist)))
@@ -72,6 +87,7 @@ open class Coverage: DomainResource {
 				presentKeys.insert("group")
 				if let val = exist as? String {
 					self.group = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "group", wants: String.self, has: type(of: exist)))
@@ -119,6 +135,7 @@ open class Coverage: DomainResource {
 				presentKeys.insert("plan")
 				if let val = exist as? String {
 					self.plan = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "plan", wants: String.self, has: type(of: exist)))
@@ -128,6 +145,7 @@ open class Coverage: DomainResource {
 				presentKeys.insert("sequence")
 				if let val = exist as? Int {
 					self.sequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequence", wants: Int.self, has: type(of: exist)))
@@ -137,6 +155,7 @@ open class Coverage: DomainResource {
 				presentKeys.insert("subPlan")
 				if let val = exist as? String {
 					self.subPlan = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "subPlan", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DataElement.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DataElement.swift
@@ -2,7 +2,7 @@
 //  DataElement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DataElement) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DataElement) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,19 +21,33 @@ open class DataElement: DomainResource {
 	}
 
 	public let contact = RealmSwift.List<DataElementContact>()
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public let element = RealmSwift.List<ElementDefinition>()
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let mapping = RealmSwift.List<DataElementMapping>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var status: String?
+	
 	public dynamic var stringency: String?
+	
 	public dynamic var url: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -61,6 +75,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -93,6 +108,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -124,6 +140,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -133,6 +150,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -142,6 +160,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -154,6 +173,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("stringency")
 				if let val = exist as? String {
 					self.stringency = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "stringency", wants: String.self, has: type(of: exist)))
@@ -163,6 +183,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -183,6 +204,7 @@ open class DataElement: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -254,7 +276,9 @@ open class DataElementContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -264,6 +288,7 @@ open class DataElementContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -311,9 +336,13 @@ open class DataElementMapping: BackboneElement {
 	}
 
 	public dynamic var comments: String?
+	
 	public dynamic var identity: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var uri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -329,6 +358,7 @@ open class DataElementMapping: BackboneElement {
 				presentKeys.insert("comments")
 				if let val = exist as? String {
 					self.comments = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comments", wants: String.self, has: type(of: exist)))
@@ -338,6 +368,7 @@ open class DataElementMapping: BackboneElement {
 				presentKeys.insert("identity")
 				if let val = exist as? String {
 					self.identity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "identity", wants: String.self, has: type(of: exist)))
@@ -350,6 +381,7 @@ open class DataElementMapping: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -359,6 +391,7 @@ open class DataElementMapping: BackboneElement {
 				presentKeys.insert("uri")
 				if let val = exist as? String {
 					self.uri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DetectedIssue.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DetectedIssue.swift
@@ -2,7 +2,7 @@
 //  DetectedIssue.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DetectedIssue) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DetectedIssue) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,15 +22,25 @@ open class DetectedIssue: DomainResource {
 	}
 
 	public dynamic var author: Reference?
+	
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var detail: String?
+	
 	public dynamic var identifier: Identifier?
+	
 	public let implicated = RealmSwift.List<Reference>()
+	
 	public let mitigation = RealmSwift.List<DetectedIssueMitigation>()
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var reference: String?
+	
 	public dynamic var severity: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -67,6 +77,7 @@ open class DetectedIssue: DomainResource {
 				presentKeys.insert("detail")
 				if let val = exist as? String {
 					self.detail = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "detail", wants: String.self, has: type(of: exist)))
@@ -116,6 +127,7 @@ open class DetectedIssue: DomainResource {
 				presentKeys.insert("reference")
 				if let val = exist as? String {
 					self.reference = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reference", wants: String.self, has: type(of: exist)))
@@ -125,6 +137,7 @@ open class DetectedIssue: DomainResource {
 				presentKeys.insert("severity")
 				if let val = exist as? String {
 					self.severity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "severity", wants: String.self, has: type(of: exist)))
@@ -186,8 +199,11 @@ open class DetectedIssueMitigation: BackboneElement {
 	}
 
 	public dynamic var action: CodeableConcept?
+	
 	public dynamic var author: Reference?
+	
 	public dynamic var date: DateTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Device.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Device.swift
@@ -2,7 +2,7 @@
 //  Device.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Device) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Device) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -25,21 +25,37 @@ open class Device: DomainResource {
 	}
 
 	public let contact = RealmSwift.List<ContactPoint>()
+	
 	public dynamic var expiry: DateTime?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var location: Reference?
+	
 	public dynamic var lotNumber: String?
+	
 	public dynamic var manufactureDate: DateTime?
+	
 	public dynamic var manufacturer: String?
+	
 	public dynamic var model: String?
+	
 	public let note = RealmSwift.List<Annotation>()
+	
 	public dynamic var owner: Reference?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public dynamic var udi: String?
+	
 	public dynamic var url: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -95,6 +111,7 @@ open class Device: DomainResource {
 				presentKeys.insert("lotNumber")
 				if let val = exist as? String {
 					self.lotNumber = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "lotNumber", wants: String.self, has: type(of: exist)))
@@ -113,6 +130,7 @@ open class Device: DomainResource {
 				presentKeys.insert("manufacturer")
 				if let val = exist as? String {
 					self.manufacturer = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "manufacturer", wants: String.self, has: type(of: exist)))
@@ -122,6 +140,7 @@ open class Device: DomainResource {
 				presentKeys.insert("model")
 				if let val = exist as? String {
 					self.model = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "model", wants: String.self, has: type(of: exist)))
@@ -160,6 +179,7 @@ open class Device: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -181,6 +201,7 @@ open class Device: DomainResource {
 				presentKeys.insert("udi")
 				if let val = exist as? String {
 					self.udi = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "udi", wants: String.self, has: type(of: exist)))
@@ -190,6 +211,7 @@ open class Device: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -199,6 +221,7 @@ open class Device: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceComponent.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceComponent.swift
@@ -2,7 +2,7 @@
 //  DeviceComponent.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceComponent) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceComponent) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,15 +22,25 @@ open class DeviceComponent: DomainResource {
 	}
 
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var languageCode: CodeableConcept?
+	
 	public dynamic var lastSystemChange: Instant?
+	
 	public dynamic var measurementPrinciple: String?
+	
 	public let operationalStatus = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var parameterGroup: CodeableConcept?
+	
 	public dynamic var parent: Reference?
+	
 	public let productionSpecification = RealmSwift.List<DeviceComponentProductionSpecification>()
+	
 	public dynamic var source: Reference?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -81,6 +91,7 @@ open class DeviceComponent: DomainResource {
 				presentKeys.insert("measurementPrinciple")
 				if let val = exist as? String {
 					self.measurementPrinciple = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "measurementPrinciple", wants: String.self, has: type(of: exist)))
@@ -201,8 +212,11 @@ open class DeviceComponentProductionSpecification: BackboneElement {
 	}
 
 	public dynamic var componentId: Identifier?
+	
 	public dynamic var productionSpec: String?
+	
 	public dynamic var specType: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -221,6 +235,7 @@ open class DeviceComponentProductionSpecification: BackboneElement {
 				presentKeys.insert("productionSpec")
 				if let val = exist as? String {
 					self.productionSpec = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "productionSpec", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceMetric.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceMetric.swift
@@ -2,7 +2,7 @@
 //  DeviceMetric.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceMetric) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceMetric) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class DeviceMetric: DomainResource {
 	}
 
 	public let calibration = RealmSwift.List<DeviceMetricCalibration>()
+	
 	public dynamic var category: String?
+	
 	public dynamic var color: String?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var measurementPeriod: Timing?
+	
 	public dynamic var operationalStatus: String?
+	
 	public dynamic var parent: Reference?
+	
 	public dynamic var source: Reference?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public dynamic var unit: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -58,6 +68,7 @@ open class DeviceMetric: DomainResource {
 				presentKeys.insert("category")
 				if let val = exist as? String {
 					self.category = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "category", wants: String.self, has: type(of: exist)))
@@ -70,6 +81,7 @@ open class DeviceMetric: DomainResource {
 				presentKeys.insert("color")
 				if let val = exist as? String {
 					self.color = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "color", wants: String.self, has: type(of: exist)))
@@ -100,6 +112,7 @@ open class DeviceMetric: DomainResource {
 				presentKeys.insert("operationalStatus")
 				if let val = exist as? String {
 					self.operationalStatus = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "operationalStatus", wants: String.self, has: type(of: exist)))
@@ -196,8 +209,11 @@ open class DeviceMetricCalibration: BackboneElement {
 	}
 
 	public dynamic var state: String?
+	
 	public dynamic var time: Instant?
+	
 	public dynamic var type: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -207,6 +223,7 @@ open class DeviceMetricCalibration: BackboneElement {
 				presentKeys.insert("state")
 				if let val = exist as? String {
 					self.state = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "state", wants: String.self, has: type(of: exist)))
@@ -225,6 +242,7 @@ open class DeviceMetricCalibration: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceUseRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceUseRequest.swift
@@ -2,7 +2,7 @@
 //  DeviceUseRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,21 +22,37 @@ open class DeviceUseRequest: DomainResource {
 	}
 
 	public dynamic var bodySiteCodeableConcept: CodeableConcept?
+	
 	public dynamic var bodySiteReference: Reference?
+	
 	public dynamic var device: Reference?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let indication = RealmSwift.List<CodeableConcept>()
+	
 	public let notes = RealmSwift.List<RealmString>()
+	
 	public dynamic var orderedOn: DateTime?
+	
 	public dynamic var priority: String?
+	
 	public let prnReason = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var recordedOn: DateTime?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var timingDateTime: DateTime?
+	
 	public dynamic var timingPeriod: Period?
+	
 	public dynamic var timingTiming: Timing?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -132,6 +148,7 @@ open class DeviceUseRequest: DomainResource {
 				presentKeys.insert("priority")
 				if let val = exist as? String {
 					self.priority = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "priority", wants: String.self, has: type(of: exist)))
@@ -161,6 +178,7 @@ open class DeviceUseRequest: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceUseStatement.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DeviceUseStatement.swift
@@ -2,7 +2,7 @@
 //  DeviceUseStatement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseStatement) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseStatement) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,17 +22,29 @@ open class DeviceUseStatement: DomainResource {
 	}
 
 	public dynamic var bodySiteCodeableConcept: CodeableConcept?
+	
 	public dynamic var bodySiteReference: Reference?
+	
 	public dynamic var device: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let indication = RealmSwift.List<CodeableConcept>()
+	
 	public let notes = RealmSwift.List<RealmString>()
+	
 	public dynamic var recordedOn: DateTime?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var timingDateTime: DateTime?
+	
 	public dynamic var timingPeriod: Period?
+	
 	public dynamic var timingTiming: Timing?
+	
 	public dynamic var whenUsed: Period?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DiagnosticOrder.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DiagnosticOrder.swift
@@ -2,7 +2,7 @@
 //  DiagnosticOrder.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticOrder) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticOrder) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,17 +21,29 @@ open class DiagnosticOrder: DomainResource {
 	}
 
 	public dynamic var encounter: Reference?
+	
 	public let event = RealmSwift.List<DiagnosticOrderEvent>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let item = RealmSwift.List<DiagnosticOrderItem>()
+	
 	public let note = RealmSwift.List<Annotation>()
+	
 	public dynamic var orderer: Reference?
+	
 	public dynamic var priority: String?
+	
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public let specimen = RealmSwift.List<Reference>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public let supportingInformation = RealmSwift.List<Reference>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -109,6 +121,7 @@ open class DiagnosticOrder: DomainResource {
 				presentKeys.insert("priority")
 				if let val = exist as? String {
 					self.priority = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "priority", wants: String.self, has: type(of: exist)))
@@ -140,6 +153,7 @@ open class DiagnosticOrder: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -229,9 +243,13 @@ open class DiagnosticOrderEvent: BackboneElement {
 	}
 
 	public dynamic var actor: Reference?
+	
 	public dynamic var dateTime: DateTime?
+	
 	public dynamic var description_fhir: CodeableConcept?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -278,6 +296,7 @@ open class DiagnosticOrderEvent: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -323,10 +342,15 @@ open class DiagnosticOrderItem: BackboneElement {
 	}
 
 	public dynamic var bodySite: CodeableConcept?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public let event = RealmSwift.List<DiagnosticOrderEvent>()
+	
 	public let specimen = RealmSwift.List<Reference>()
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -385,6 +409,7 @@ open class DiagnosticOrderItem: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DiagnosticReport.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DiagnosticReport.swift
@@ -2,7 +2,7 @@
 //  DiagnosticReport.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticReport) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticReport) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -25,23 +25,41 @@ open class DiagnosticReport: DomainResource {
 	}
 
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public let codedDiagnosis = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var conclusion: String?
+	
 	public dynamic var effectiveDateTime: DateTime?
+	
 	public dynamic var effectivePeriod: Period?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let image = RealmSwift.List<DiagnosticReportImage>()
+	
 	public let imagingStudy = RealmSwift.List<Reference>()
+	
 	public dynamic var issued: Instant?
+	
 	public dynamic var performer: Reference?
+	
 	public let presentedForm = RealmSwift.List<Attachment>()
+	
 	public let request = RealmSwift.List<Reference>()
+	
 	public let result = RealmSwift.List<Reference>()
+	
 	public let specimen = RealmSwift.List<Reference>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -95,6 +113,7 @@ open class DiagnosticReport: DomainResource {
 				presentKeys.insert("conclusion")
 				if let val = exist as? String {
 					self.conclusion = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "conclusion", wants: String.self, has: type(of: exist)))
@@ -232,6 +251,7 @@ open class DiagnosticReport: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -336,7 +356,9 @@ open class DiagnosticReportImage: BackboneElement {
 	}
 
 	public dynamic var comment: String?
+	
 	public dynamic var link: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -352,6 +374,7 @@ open class DiagnosticReportImage: BackboneElement {
 				presentKeys.insert("comment")
 				if let val = exist as? String {
 					self.comment = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comment", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Distance.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Distance.swift
@@ -2,7 +2,7 @@
 //  Distance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Distance) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Distance) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DocumentManifest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DocumentManifest.swift
@@ -2,7 +2,7 @@
 //  DocumentManifest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentManifest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentManifest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,17 +19,29 @@ open class DocumentManifest: DomainResource {
 	}
 
 	public let author = RealmSwift.List<Reference>()
+	
 	public let content = RealmSwift.List<DocumentManifestContent>()
+	
 	public dynamic var created: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var masterIdentifier: Identifier?
+	
 	public let recipient = RealmSwift.List<Reference>()
+	
 	public let related = RealmSwift.List<DocumentManifestRelated>()
+	
 	public dynamic var source: String?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -80,6 +92,7 @@ open class DocumentManifest: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -131,6 +144,7 @@ open class DocumentManifest: DomainResource {
 				presentKeys.insert("source")
 				if let val = exist as? String {
 					self.source = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "source", wants: String.self, has: type(of: exist)))
@@ -140,6 +154,7 @@ open class DocumentManifest: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -226,7 +241,9 @@ open class DocumentManifestContent: BackboneElement {
 	}
 
 	public dynamic var pAttachment: Attachment?
+	
 	public dynamic var pReference: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -292,7 +309,9 @@ open class DocumentManifestRelated: BackboneElement {
 	}
 
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var ref: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DocumentReference.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DocumentReference.swift
@@ -2,7 +2,7 @@
 //  DocumentReference.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentReference) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentReference) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,22 +21,39 @@ open class DocumentReference: DomainResource {
 	}
 
 	public dynamic var authenticator: Reference?
+	
 	public let author = RealmSwift.List<Reference>()
+	
 	public dynamic var class_fhir: CodeableConcept?
+	
 	public let content = RealmSwift.List<DocumentReferenceContent>()
+	
 	public dynamic var context: DocumentReferenceContext?
+	
 	public dynamic var created: DateTime?
+	
 	public dynamic var custodian: Reference?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var docStatus: CodeableConcept?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var indexed: Instant?
+	
 	public dynamic var masterIdentifier: Identifier?
+	
 	public let relatesTo = RealmSwift.List<DocumentReferenceRelatesTo>()
+	
 	public let securityLabel = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -125,6 +142,7 @@ open class DocumentReference: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -197,6 +215,7 @@ open class DocumentReference: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -301,7 +320,9 @@ open class DocumentReferenceContent: BackboneElement {
 	}
 
 	public dynamic var attachment: Attachment?
+	
 	public let format = RealmSwift.List<Coding>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -366,12 +387,19 @@ open class DocumentReferenceContext: BackboneElement {
 	}
 
 	public dynamic var encounter: Reference?
+	
 	public let event = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var facilityType: CodeableConcept?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var practiceSetting: CodeableConcept?
+	
 	public let related = RealmSwift.List<DocumentReferenceContextRelated>()
+	
 	public dynamic var sourcePatientInfo: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -489,7 +517,9 @@ open class DocumentReferenceContextRelated: BackboneElement {
 	}
 
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var ref: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -543,7 +573,9 @@ open class DocumentReferenceRelatesTo: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -560,6 +592,7 @@ open class DocumentReferenceRelatesTo: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/DomainResource.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/DomainResource.swift
@@ -2,7 +2,7 @@
 //  DomainResource.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DomainResource) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DomainResource) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,9 +21,13 @@ open class DomainResource: Resource {
 	}
 
 	public let contained = RealmSwift.List<ContainedResource>()
+	
 	public let extension_fhir = RealmSwift.List<Extension>()
+	
 	public let modifierExtension = RealmSwift.List<Extension>()
+	
 	public dynamic var text: Narrative?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Duration.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Duration.swift
@@ -2,7 +2,7 @@
 //  Duration.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Duration) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Duration) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Element.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Element.swift
@@ -2,7 +2,7 @@
 //  Element.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Element) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Element) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,9 +21,11 @@ open class Element: FHIRAbstractBase {
 	}
 
 	public let extension_fhir = RealmSwift.List<Extension>()
-	public dynamic var id = UUID().uuidString
+	
+	public dynamic var id: String?
+	public dynamic var pk = UUID().uuidString
 	override open static func primaryKey() -> String? {
-		return "id"
+		return "pk"
 	}
 
 	
@@ -45,6 +47,7 @@ open class Element: FHIRAbstractBase {
 				presentKeys.insert("id")
 				if let val = exist as? String {
 					self.id = val
+					self.pk = val
 				}
 				else {
 					errors.append(FHIRJSONError(key: "id", wants: String.self, has: type(of: exist)))
@@ -60,7 +63,9 @@ open class Element: FHIRAbstractBase {
 		if extension_fhir.count > 0 {
 			json["extension"] = Array(extension_fhir.map() { $0.asJSON() })
 		}
+		if let id = self.id {
 			json["id"] = id.asJSON()
+		}
 		
 		return json
 	}

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ElementDefinition.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ElementDefinition.swift
@@ -2,7 +2,7 @@
 //  ElementDefinition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ElementDefinition) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ElementDefinition) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,228 +21,451 @@ open class ElementDefinition: Element {
 	}
 
 	public let alias = RealmSwift.List<RealmString>()
+	
 	public dynamic var base: ElementDefinitionBase?
+	
 	public dynamic var binding: ElementDefinitionBinding?
+	
 	public let code = RealmSwift.List<Coding>()
+	
 	public dynamic var comments: String?
+	
 	public let condition = RealmSwift.List<RealmString>()
+	
 	public let constraint = RealmSwift.List<ElementDefinitionConstraint>()
+	
 	public dynamic var defaultValueAddress: Address?
+	
 	public dynamic var defaultValueAnnotation: Annotation?
+	
 	public dynamic var defaultValueAttachment: Attachment?
+	
 	public dynamic var defaultValueBase64Binary: Base64Binary?
+	
 	public let defaultValueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var defaultValueCode: String?
+	
 	public dynamic var defaultValueCodeableConcept: CodeableConcept?
+	
 	public dynamic var defaultValueCoding: Coding?
+	
 	public dynamic var defaultValueContactPoint: ContactPoint?
+	
 	public dynamic var defaultValueDate: FHIRDate?
+	
 	public dynamic var defaultValueDateTime: DateTime?
+	
 	public dynamic var defaultValueDecimal: RealmDecimal?
+	
 	public dynamic var defaultValueHumanName: HumanName?
+	
 	public dynamic var defaultValueId: String?
+	
 	public dynamic var defaultValueIdentifier: Identifier?
+	
 	public dynamic var defaultValueInstant: Instant?
+	
 	public let defaultValueInteger = RealmOptional<Int>()
+	
 	public dynamic var defaultValueMarkdown: String?
+	
 	public dynamic var defaultValueMeta: Meta?
+	
 	public dynamic var defaultValueOid: String?
+	
 	public dynamic var defaultValuePeriod: Period?
+	
 	public let defaultValuePositiveInt = RealmOptional<Int>()
+	
 	public dynamic var defaultValueQuantity: Quantity?
+	
 	public dynamic var defaultValueRange: Range?
+	
 	public dynamic var defaultValueRatio: Ratio?
+	
 	public dynamic var defaultValueReference: Reference?
+	
 	public dynamic var defaultValueSampledData: SampledData?
+	
 	public dynamic var defaultValueSignature: Signature?
+	
 	public dynamic var defaultValueString: String?
+	
 	public dynamic var defaultValueTime: FHIRTime?
+	
 	public dynamic var defaultValueTiming: Timing?
+	
 	public let defaultValueUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var defaultValueUri: String?
+	
 	public dynamic var definition: String?
+	
 	public dynamic var exampleAddress: Address?
+	
 	public dynamic var exampleAnnotation: Annotation?
+	
 	public dynamic var exampleAttachment: Attachment?
+	
 	public dynamic var exampleBase64Binary: Base64Binary?
+	
 	public let exampleBoolean = RealmOptional<Bool>()
+	
 	public dynamic var exampleCode: String?
+	
 	public dynamic var exampleCodeableConcept: CodeableConcept?
+	
 	public dynamic var exampleCoding: Coding?
+	
 	public dynamic var exampleContactPoint: ContactPoint?
+	
 	public dynamic var exampleDate: FHIRDate?
+	
 	public dynamic var exampleDateTime: DateTime?
+	
 	public dynamic var exampleDecimal: RealmDecimal?
+	
 	public dynamic var exampleHumanName: HumanName?
+	
 	public dynamic var exampleId: String?
+	
 	public dynamic var exampleIdentifier: Identifier?
+	
 	public dynamic var exampleInstant: Instant?
+	
 	public let exampleInteger = RealmOptional<Int>()
+	
 	public dynamic var exampleMarkdown: String?
+	
 	public dynamic var exampleMeta: Meta?
+	
 	public dynamic var exampleOid: String?
+	
 	public dynamic var examplePeriod: Period?
+	
 	public let examplePositiveInt = RealmOptional<Int>()
+	
 	public dynamic var exampleQuantity: Quantity?
+	
 	public dynamic var exampleRange: Range?
+	
 	public dynamic var exampleRatio: Ratio?
+	
 	public dynamic var exampleReference: Reference?
+	
 	public dynamic var exampleSampledData: SampledData?
+	
 	public dynamic var exampleSignature: Signature?
+	
 	public dynamic var exampleString: String?
+	
 	public dynamic var exampleTime: FHIRTime?
+	
 	public dynamic var exampleTiming: Timing?
+	
 	public let exampleUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var exampleUri: String?
+	
 	public dynamic var fixedAddress: Address?
+	
 	public dynamic var fixedAnnotation: Annotation?
+	
 	public dynamic var fixedAttachment: Attachment?
+	
 	public dynamic var fixedBase64Binary: Base64Binary?
+	
 	public let fixedBoolean = RealmOptional<Bool>()
+	
 	public dynamic var fixedCode: String?
+	
 	public dynamic var fixedCodeableConcept: CodeableConcept?
+	
 	public dynamic var fixedCoding: Coding?
+	
 	public dynamic var fixedContactPoint: ContactPoint?
+	
 	public dynamic var fixedDate: FHIRDate?
+	
 	public dynamic var fixedDateTime: DateTime?
+	
 	public dynamic var fixedDecimal: RealmDecimal?
+	
 	public dynamic var fixedHumanName: HumanName?
+	
 	public dynamic var fixedId: String?
+	
 	public dynamic var fixedIdentifier: Identifier?
+	
 	public dynamic var fixedInstant: Instant?
+	
 	public let fixedInteger = RealmOptional<Int>()
+	
 	public dynamic var fixedMarkdown: String?
+	
 	public dynamic var fixedMeta: Meta?
+	
 	public dynamic var fixedOid: String?
+	
 	public dynamic var fixedPeriod: Period?
+	
 	public let fixedPositiveInt = RealmOptional<Int>()
+	
 	public dynamic var fixedQuantity: Quantity?
+	
 	public dynamic var fixedRange: Range?
+	
 	public dynamic var fixedRatio: Ratio?
+	
 	public dynamic var fixedReference: Reference?
+	
 	public dynamic var fixedSampledData: SampledData?
+	
 	public dynamic var fixedSignature: Signature?
+	
 	public dynamic var fixedString: String?
+	
 	public dynamic var fixedTime: FHIRTime?
+	
 	public dynamic var fixedTiming: Timing?
+	
 	public let fixedUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var fixedUri: String?
+	
 	public let isModifier = RealmOptional<Bool>()
+	
 	public let isSummary = RealmOptional<Bool>()
+	
 	public dynamic var label: String?
+	
 	public let mapping = RealmSwift.List<ElementDefinitionMapping>()
+	
 	public dynamic var max: String?
+	
 	public let maxLength = RealmOptional<Int>()
+	
 	public dynamic var maxValueAddress: Address?
+	
 	public dynamic var maxValueAnnotation: Annotation?
+	
 	public dynamic var maxValueAttachment: Attachment?
+	
 	public dynamic var maxValueBase64Binary: Base64Binary?
+	
 	public let maxValueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var maxValueCode: String?
+	
 	public dynamic var maxValueCodeableConcept: CodeableConcept?
+	
 	public dynamic var maxValueCoding: Coding?
+	
 	public dynamic var maxValueContactPoint: ContactPoint?
+	
 	public dynamic var maxValueDate: FHIRDate?
+	
 	public dynamic var maxValueDateTime: DateTime?
+	
 	public dynamic var maxValueDecimal: RealmDecimal?
+	
 	public dynamic var maxValueHumanName: HumanName?
+	
 	public dynamic var maxValueId: String?
+	
 	public dynamic var maxValueIdentifier: Identifier?
+	
 	public dynamic var maxValueInstant: Instant?
+	
 	public let maxValueInteger = RealmOptional<Int>()
+	
 	public dynamic var maxValueMarkdown: String?
+	
 	public dynamic var maxValueMeta: Meta?
+	
 	public dynamic var maxValueOid: String?
+	
 	public dynamic var maxValuePeriod: Period?
+	
 	public let maxValuePositiveInt = RealmOptional<Int>()
+	
 	public dynamic var maxValueQuantity: Quantity?
+	
 	public dynamic var maxValueRange: Range?
+	
 	public dynamic var maxValueRatio: Ratio?
+	
 	public dynamic var maxValueReference: Reference?
+	
 	public dynamic var maxValueSampledData: SampledData?
+	
 	public dynamic var maxValueSignature: Signature?
+	
 	public dynamic var maxValueString: String?
+	
 	public dynamic var maxValueTime: FHIRTime?
+	
 	public dynamic var maxValueTiming: Timing?
+	
 	public let maxValueUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var maxValueUri: String?
+	
 	public dynamic var meaningWhenMissing: String?
+	
 	public let min = RealmOptional<Int>()
+	
 	public dynamic var minValueAddress: Address?
+	
 	public dynamic var minValueAnnotation: Annotation?
+	
 	public dynamic var minValueAttachment: Attachment?
+	
 	public dynamic var minValueBase64Binary: Base64Binary?
+	
 	public let minValueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var minValueCode: String?
+	
 	public dynamic var minValueCodeableConcept: CodeableConcept?
+	
 	public dynamic var minValueCoding: Coding?
+	
 	public dynamic var minValueContactPoint: ContactPoint?
+	
 	public dynamic var minValueDate: FHIRDate?
+	
 	public dynamic var minValueDateTime: DateTime?
+	
 	public dynamic var minValueDecimal: RealmDecimal?
+	
 	public dynamic var minValueHumanName: HumanName?
+	
 	public dynamic var minValueId: String?
+	
 	public dynamic var minValueIdentifier: Identifier?
+	
 	public dynamic var minValueInstant: Instant?
+	
 	public let minValueInteger = RealmOptional<Int>()
+	
 	public dynamic var minValueMarkdown: String?
+	
 	public dynamic var minValueMeta: Meta?
+	
 	public dynamic var minValueOid: String?
+	
 	public dynamic var minValuePeriod: Period?
+	
 	public let minValuePositiveInt = RealmOptional<Int>()
+	
 	public dynamic var minValueQuantity: Quantity?
+	
 	public dynamic var minValueRange: Range?
+	
 	public dynamic var minValueRatio: Ratio?
+	
 	public dynamic var minValueReference: Reference?
+	
 	public dynamic var minValueSampledData: SampledData?
+	
 	public dynamic var minValueSignature: Signature?
+	
 	public dynamic var minValueString: String?
+	
 	public dynamic var minValueTime: FHIRTime?
+	
 	public dynamic var minValueTiming: Timing?
+	
 	public let minValueUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var minValueUri: String?
+	
 	public let mustSupport = RealmOptional<Bool>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var nameReference: String?
+	
 	public dynamic var path: String?
+	
 	public dynamic var patternAddress: Address?
+	
 	public dynamic var patternAnnotation: Annotation?
+	
 	public dynamic var patternAttachment: Attachment?
+	
 	public dynamic var patternBase64Binary: Base64Binary?
+	
 	public let patternBoolean = RealmOptional<Bool>()
+	
 	public dynamic var patternCode: String?
+	
 	public dynamic var patternCodeableConcept: CodeableConcept?
+	
 	public dynamic var patternCoding: Coding?
+	
 	public dynamic var patternContactPoint: ContactPoint?
+	
 	public dynamic var patternDate: FHIRDate?
+	
 	public dynamic var patternDateTime: DateTime?
+	
 	public dynamic var patternDecimal: RealmDecimal?
+	
 	public dynamic var patternHumanName: HumanName?
+	
 	public dynamic var patternId: String?
+	
 	public dynamic var patternIdentifier: Identifier?
+	
 	public dynamic var patternInstant: Instant?
+	
 	public let patternInteger = RealmOptional<Int>()
+	
 	public dynamic var patternMarkdown: String?
+	
 	public dynamic var patternMeta: Meta?
+	
 	public dynamic var patternOid: String?
+	
 	public dynamic var patternPeriod: Period?
+	
 	public let patternPositiveInt = RealmOptional<Int>()
+	
 	public dynamic var patternQuantity: Quantity?
+	
 	public dynamic var patternRange: Range?
+	
 	public dynamic var patternRatio: Ratio?
+	
 	public dynamic var patternReference: Reference?
+	
 	public dynamic var patternSampledData: SampledData?
+	
 	public dynamic var patternSignature: Signature?
+	
 	public dynamic var patternString: String?
+	
 	public dynamic var patternTime: FHIRTime?
+	
 	public dynamic var patternTiming: Timing?
+	
 	public let patternUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var patternUri: String?
+	
 	public let representation = RealmSwift.List<RealmString>()
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var short: String?
+	
 	public dynamic var slicing: ElementDefinitionSlicing?
+	
 	public let type = RealmSwift.List<ElementDefinitionType>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -296,6 +519,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("comments")
 				if let val = exist as? String {
 					self.comments = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comments", wants: String.self, has: type(of: exist)))
@@ -361,6 +585,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueBoolean")
 				if let val = exist as? Bool {
 					self.defaultValueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -370,6 +595,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueCode")
 				if let val = exist as? String {
 					self.defaultValueCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueCode", wants: String.self, has: type(of: exist)))
@@ -442,6 +668,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueId")
 				if let val = exist as? String {
 					self.defaultValueId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueId", wants: String.self, has: type(of: exist)))
@@ -469,6 +696,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueInteger")
 				if let val = exist as? Int {
 					self.defaultValueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueInteger", wants: Int.self, has: type(of: exist)))
@@ -478,6 +706,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueMarkdown")
 				if let val = exist as? String {
 					self.defaultValueMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueMarkdown", wants: String.self, has: type(of: exist)))
@@ -496,6 +725,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueOid")
 				if let val = exist as? String {
 					self.defaultValueOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueOid", wants: String.self, has: type(of: exist)))
@@ -514,6 +744,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValuePositiveInt")
 				if let val = exist as? Int {
 					self.defaultValuePositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValuePositiveInt", wants: Int.self, has: type(of: exist)))
@@ -577,6 +808,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueString")
 				if let val = exist as? String {
 					self.defaultValueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueString", wants: String.self, has: type(of: exist)))
@@ -604,6 +836,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueUnsignedInt")
 				if let val = exist as? Int {
 					self.defaultValueUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -613,6 +846,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("defaultValueUri")
 				if let val = exist as? String {
 					self.defaultValueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "defaultValueUri", wants: String.self, has: type(of: exist)))
@@ -622,6 +856,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("definition")
 				if let val = exist as? String {
 					self.definition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "definition", wants: String.self, has: type(of: exist)))
@@ -667,6 +902,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleBoolean")
 				if let val = exist as? Bool {
 					self.exampleBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleBoolean", wants: Bool.self, has: type(of: exist)))
@@ -676,6 +912,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleCode")
 				if let val = exist as? String {
 					self.exampleCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleCode", wants: String.self, has: type(of: exist)))
@@ -748,6 +985,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleId")
 				if let val = exist as? String {
 					self.exampleId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleId", wants: String.self, has: type(of: exist)))
@@ -775,6 +1013,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleInteger")
 				if let val = exist as? Int {
 					self.exampleInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleInteger", wants: Int.self, has: type(of: exist)))
@@ -784,6 +1023,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleMarkdown")
 				if let val = exist as? String {
 					self.exampleMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleMarkdown", wants: String.self, has: type(of: exist)))
@@ -802,6 +1042,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleOid")
 				if let val = exist as? String {
 					self.exampleOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleOid", wants: String.self, has: type(of: exist)))
@@ -820,6 +1061,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("examplePositiveInt")
 				if let val = exist as? Int {
 					self.examplePositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "examplePositiveInt", wants: Int.self, has: type(of: exist)))
@@ -883,6 +1125,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleString")
 				if let val = exist as? String {
 					self.exampleString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleString", wants: String.self, has: type(of: exist)))
@@ -910,6 +1153,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleUnsignedInt")
 				if let val = exist as? Int {
 					self.exampleUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -919,6 +1163,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("exampleUri")
 				if let val = exist as? String {
 					self.exampleUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exampleUri", wants: String.self, has: type(of: exist)))
@@ -964,6 +1209,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedBoolean")
 				if let val = exist as? Bool {
 					self.fixedBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedBoolean", wants: Bool.self, has: type(of: exist)))
@@ -973,6 +1219,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedCode")
 				if let val = exist as? String {
 					self.fixedCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedCode", wants: String.self, has: type(of: exist)))
@@ -1045,6 +1292,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedId")
 				if let val = exist as? String {
 					self.fixedId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedId", wants: String.self, has: type(of: exist)))
@@ -1072,6 +1320,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedInteger")
 				if let val = exist as? Int {
 					self.fixedInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedInteger", wants: Int.self, has: type(of: exist)))
@@ -1081,6 +1330,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedMarkdown")
 				if let val = exist as? String {
 					self.fixedMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedMarkdown", wants: String.self, has: type(of: exist)))
@@ -1099,6 +1349,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedOid")
 				if let val = exist as? String {
 					self.fixedOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedOid", wants: String.self, has: type(of: exist)))
@@ -1117,6 +1368,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedPositiveInt")
 				if let val = exist as? Int {
 					self.fixedPositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedPositiveInt", wants: Int.self, has: type(of: exist)))
@@ -1180,6 +1432,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedString")
 				if let val = exist as? String {
 					self.fixedString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedString", wants: String.self, has: type(of: exist)))
@@ -1207,6 +1460,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedUnsignedInt")
 				if let val = exist as? Int {
 					self.fixedUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -1216,6 +1470,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("fixedUri")
 				if let val = exist as? String {
 					self.fixedUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fixedUri", wants: String.self, has: type(of: exist)))
@@ -1225,6 +1480,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("isModifier")
 				if let val = exist as? Bool {
 					self.isModifier.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "isModifier", wants: Bool.self, has: type(of: exist)))
@@ -1234,6 +1490,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("isSummary")
 				if let val = exist as? Bool {
 					self.isSummary.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "isSummary", wants: Bool.self, has: type(of: exist)))
@@ -1243,6 +1500,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("label")
 				if let val = exist as? String {
 					self.label = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "label", wants: String.self, has: type(of: exist)))
@@ -1263,6 +1521,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("max")
 				if let val = exist as? String {
 					self.max = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "max", wants: String.self, has: type(of: exist)))
@@ -1272,6 +1531,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxLength")
 				if let val = exist as? Int {
 					self.maxLength.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxLength", wants: Int.self, has: type(of: exist)))
@@ -1317,6 +1577,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueBoolean")
 				if let val = exist as? Bool {
 					self.maxValueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -1326,6 +1587,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueCode")
 				if let val = exist as? String {
 					self.maxValueCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueCode", wants: String.self, has: type(of: exist)))
@@ -1398,6 +1660,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueId")
 				if let val = exist as? String {
 					self.maxValueId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueId", wants: String.self, has: type(of: exist)))
@@ -1425,6 +1688,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueInteger")
 				if let val = exist as? Int {
 					self.maxValueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueInteger", wants: Int.self, has: type(of: exist)))
@@ -1434,6 +1698,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueMarkdown")
 				if let val = exist as? String {
 					self.maxValueMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueMarkdown", wants: String.self, has: type(of: exist)))
@@ -1452,6 +1717,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueOid")
 				if let val = exist as? String {
 					self.maxValueOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueOid", wants: String.self, has: type(of: exist)))
@@ -1470,6 +1736,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValuePositiveInt")
 				if let val = exist as? Int {
 					self.maxValuePositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValuePositiveInt", wants: Int.self, has: type(of: exist)))
@@ -1533,6 +1800,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueString")
 				if let val = exist as? String {
 					self.maxValueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueString", wants: String.self, has: type(of: exist)))
@@ -1560,6 +1828,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueUnsignedInt")
 				if let val = exist as? Int {
 					self.maxValueUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -1569,6 +1838,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("maxValueUri")
 				if let val = exist as? String {
 					self.maxValueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "maxValueUri", wants: String.self, has: type(of: exist)))
@@ -1578,6 +1848,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("meaningWhenMissing")
 				if let val = exist as? String {
 					self.meaningWhenMissing = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "meaningWhenMissing", wants: String.self, has: type(of: exist)))
@@ -1587,6 +1858,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("min")
 				if let val = exist as? Int {
 					self.min.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "min", wants: Int.self, has: type(of: exist)))
@@ -1632,6 +1904,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueBoolean")
 				if let val = exist as? Bool {
 					self.minValueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -1641,6 +1914,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueCode")
 				if let val = exist as? String {
 					self.minValueCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueCode", wants: String.self, has: type(of: exist)))
@@ -1713,6 +1987,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueId")
 				if let val = exist as? String {
 					self.minValueId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueId", wants: String.self, has: type(of: exist)))
@@ -1740,6 +2015,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueInteger")
 				if let val = exist as? Int {
 					self.minValueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueInteger", wants: Int.self, has: type(of: exist)))
@@ -1749,6 +2025,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueMarkdown")
 				if let val = exist as? String {
 					self.minValueMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueMarkdown", wants: String.self, has: type(of: exist)))
@@ -1767,6 +2044,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueOid")
 				if let val = exist as? String {
 					self.minValueOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueOid", wants: String.self, has: type(of: exist)))
@@ -1785,6 +2063,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValuePositiveInt")
 				if let val = exist as? Int {
 					self.minValuePositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValuePositiveInt", wants: Int.self, has: type(of: exist)))
@@ -1848,6 +2127,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueString")
 				if let val = exist as? String {
 					self.minValueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueString", wants: String.self, has: type(of: exist)))
@@ -1875,6 +2155,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueUnsignedInt")
 				if let val = exist as? Int {
 					self.minValueUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -1884,6 +2165,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("minValueUri")
 				if let val = exist as? String {
 					self.minValueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minValueUri", wants: String.self, has: type(of: exist)))
@@ -1893,6 +2175,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("mustSupport")
 				if let val = exist as? Bool {
 					self.mustSupport.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mustSupport", wants: Bool.self, has: type(of: exist)))
@@ -1902,6 +2185,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1911,6 +2195,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("nameReference")
 				if let val = exist as? String {
 					self.nameReference = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "nameReference", wants: String.self, has: type(of: exist)))
@@ -1920,6 +2205,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("path")
 				if let val = exist as? String {
 					self.path = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "path", wants: String.self, has: type(of: exist)))
@@ -1968,6 +2254,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternBoolean")
 				if let val = exist as? Bool {
 					self.patternBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternBoolean", wants: Bool.self, has: type(of: exist)))
@@ -1977,6 +2264,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternCode")
 				if let val = exist as? String {
 					self.patternCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternCode", wants: String.self, has: type(of: exist)))
@@ -2049,6 +2337,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternId")
 				if let val = exist as? String {
 					self.patternId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternId", wants: String.self, has: type(of: exist)))
@@ -2076,6 +2365,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternInteger")
 				if let val = exist as? Int {
 					self.patternInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternInteger", wants: Int.self, has: type(of: exist)))
@@ -2085,6 +2375,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternMarkdown")
 				if let val = exist as? String {
 					self.patternMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternMarkdown", wants: String.self, has: type(of: exist)))
@@ -2103,6 +2394,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternOid")
 				if let val = exist as? String {
 					self.patternOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternOid", wants: String.self, has: type(of: exist)))
@@ -2121,6 +2413,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternPositiveInt")
 				if let val = exist as? Int {
 					self.patternPositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternPositiveInt", wants: Int.self, has: type(of: exist)))
@@ -2184,6 +2477,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternString")
 				if let val = exist as? String {
 					self.patternString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternString", wants: String.self, has: type(of: exist)))
@@ -2211,6 +2505,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternUnsignedInt")
 				if let val = exist as? Int {
 					self.patternUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -2220,6 +2515,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("patternUri")
 				if let val = exist as? String {
 					self.patternUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "patternUri", wants: String.self, has: type(of: exist)))
@@ -2238,6 +2534,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -2247,6 +2544,7 @@ open class ElementDefinition: Element {
 				presentKeys.insert("short")
 				if let val = exist as? String {
 					self.short = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "short", wants: String.self, has: type(of: exist)))
@@ -2968,8 +3266,11 @@ open class ElementDefinitionBase: Element {
 	}
 
 	public dynamic var max: String?
+	
 	public let min = RealmOptional<Int>()
+	
 	public dynamic var path: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -2987,6 +3288,7 @@ open class ElementDefinitionBase: Element {
 				presentKeys.insert("max")
 				if let val = exist as? String {
 					self.max = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "max", wants: String.self, has: type(of: exist)))
@@ -2999,6 +3301,7 @@ open class ElementDefinitionBase: Element {
 				presentKeys.insert("min")
 				if let val = exist as? Int {
 					self.min.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "min", wants: Int.self, has: type(of: exist)))
@@ -3011,6 +3314,7 @@ open class ElementDefinitionBase: Element {
 				presentKeys.insert("path")
 				if let val = exist as? String {
 					self.path = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "path", wants: String.self, has: type(of: exist)))
@@ -3052,9 +3356,13 @@ open class ElementDefinitionBinding: Element {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public dynamic var strength: String?
+	
 	public dynamic var valueSetReference: Reference?
+	
 	public dynamic var valueSetUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -3070,6 +3378,7 @@ open class ElementDefinitionBinding: Element {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -3079,6 +3388,7 @@ open class ElementDefinitionBinding: Element {
 				presentKeys.insert("strength")
 				if let val = exist as? String {
 					self.strength = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "strength", wants: String.self, has: type(of: exist)))
@@ -3100,6 +3410,7 @@ open class ElementDefinitionBinding: Element {
 				presentKeys.insert("valueSetUri")
 				if let val = exist as? String {
 					self.valueSetUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueSetUri", wants: String.self, has: type(of: exist)))
@@ -3142,10 +3453,15 @@ open class ElementDefinitionConstraint: Element {
 	}
 
 	public dynamic var human: String?
+	
 	public dynamic var key: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var severity: String?
+	
 	public dynamic var xpath: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -3164,6 +3480,7 @@ open class ElementDefinitionConstraint: Element {
 				presentKeys.insert("human")
 				if let val = exist as? String {
 					self.human = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "human", wants: String.self, has: type(of: exist)))
@@ -3176,6 +3493,7 @@ open class ElementDefinitionConstraint: Element {
 				presentKeys.insert("key")
 				if let val = exist as? String {
 					self.key = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "key", wants: String.self, has: type(of: exist)))
@@ -3188,6 +3506,7 @@ open class ElementDefinitionConstraint: Element {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -3197,6 +3516,7 @@ open class ElementDefinitionConstraint: Element {
 				presentKeys.insert("severity")
 				if let val = exist as? String {
 					self.severity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "severity", wants: String.self, has: type(of: exist)))
@@ -3209,6 +3529,7 @@ open class ElementDefinitionConstraint: Element {
 				presentKeys.insert("xpath")
 				if let val = exist as? String {
 					self.xpath = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "xpath", wants: String.self, has: type(of: exist)))
@@ -3256,8 +3577,11 @@ open class ElementDefinitionMapping: Element {
 	}
 
 	public dynamic var identity: String?
+	
 	public dynamic var language: String?
+	
 	public dynamic var map: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -3274,6 +3598,7 @@ open class ElementDefinitionMapping: Element {
 				presentKeys.insert("identity")
 				if let val = exist as? String {
 					self.identity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "identity", wants: String.self, has: type(of: exist)))
@@ -3286,6 +3611,7 @@ open class ElementDefinitionMapping: Element {
 				presentKeys.insert("language")
 				if let val = exist as? String {
 					self.language = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "language", wants: String.self, has: type(of: exist)))
@@ -3295,6 +3621,7 @@ open class ElementDefinitionMapping: Element {
 				presentKeys.insert("map")
 				if let val = exist as? String {
 					self.map = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "map", wants: String.self, has: type(of: exist)))
@@ -3340,9 +3667,13 @@ open class ElementDefinitionSlicing: Element {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public let discriminator = RealmSwift.List<RealmString>()
+	
 	public let ordered = RealmOptional<Bool>()
+	
 	public dynamic var rules: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -3358,6 +3689,7 @@ open class ElementDefinitionSlicing: Element {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -3376,6 +3708,7 @@ open class ElementDefinitionSlicing: Element {
 				presentKeys.insert("ordered")
 				if let val = exist as? Bool {
 					self.ordered.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "ordered", wants: Bool.self, has: type(of: exist)))
@@ -3385,6 +3718,7 @@ open class ElementDefinitionSlicing: Element {
 				presentKeys.insert("rules")
 				if let val = exist as? String {
 					self.rules = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "rules", wants: String.self, has: type(of: exist)))
@@ -3429,8 +3763,11 @@ open class ElementDefinitionType: Element {
 	}
 
 	public let aggregation = RealmSwift.List<RealmString>()
+	
 	public dynamic var code: String?
+	
 	public let profile = RealmSwift.List<RealmString>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -3455,6 +3792,7 @@ open class ElementDefinitionType: Element {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/EligibilityRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/EligibilityRequest.swift
@@ -2,7 +2,7 @@
 //  EligibilityRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,12 +22,19 @@ open class EligibilityRequest: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/EligibilityResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/EligibilityResponse.swift
@@ -2,7 +2,7 @@
 //  EligibilityResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class EligibilityResponse: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public dynamic var disposition: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var outcome: String?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var requestOrganization: Reference?
+	
 	public dynamic var requestProvider: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -48,6 +58,7 @@ open class EligibilityResponse: DomainResource {
 				presentKeys.insert("disposition")
 				if let val = exist as? String {
 					self.disposition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "disposition", wants: String.self, has: type(of: exist)))
@@ -86,6 +97,7 @@ open class EligibilityResponse: DomainResource {
 				presentKeys.insert("outcome")
 				if let val = exist as? String {
 					self.outcome = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcome", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Encounter.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Encounter.swift
@@ -2,7 +2,7 @@
 //  Encounter.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Encounter) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Encounter) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,24 +22,43 @@ open class Encounter: DomainResource {
 	}
 
 	public dynamic var appointment: Reference?
+	
 	public dynamic var class_fhir: String?
+	
 	public let episodeOfCare = RealmSwift.List<Reference>()
+	
 	public dynamic var hospitalization: EncounterHospitalization?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let incomingReferral = RealmSwift.List<Reference>()
+	
 	public let indication = RealmSwift.List<Reference>()
+	
 	public dynamic var length: Quantity?
+	
 	public let location = RealmSwift.List<EncounterLocation>()
+	
 	public dynamic var partOf: Reference?
+	
 	public let participant = RealmSwift.List<EncounterParticipant>()
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var priority: CodeableConcept?
+	
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var serviceProvider: Reference?
+	
 	public dynamic var status: String?
+	
 	public let statusHistory = RealmSwift.List<EncounterStatusHistory>()
+	
 	public let type = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -64,6 +83,7 @@ open class Encounter: DomainResource {
 				presentKeys.insert("class")
 				if let val = exist as? String {
 					self.class_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "class", wants: String.self, has: type(of: exist)))
@@ -213,6 +233,7 @@ open class Encounter: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -322,16 +343,27 @@ open class EncounterHospitalization: BackboneElement {
 	}
 
 	public dynamic var admitSource: CodeableConcept?
+	
 	public let admittingDiagnosis = RealmSwift.List<Reference>()
+	
 	public dynamic var destination: Reference?
+	
 	public let dietPreference = RealmSwift.List<CodeableConcept>()
+	
 	public let dischargeDiagnosis = RealmSwift.List<Reference>()
+	
 	public dynamic var dischargeDisposition: CodeableConcept?
+	
 	public dynamic var origin: Reference?
+	
 	public dynamic var preAdmissionIdentifier: Identifier?
+	
 	public dynamic var reAdmission: CodeableConcept?
+	
 	public let specialArrangement = RealmSwift.List<CodeableConcept>()
+	
 	public let specialCourtesy = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -503,8 +535,11 @@ open class EncounterLocation: BackboneElement {
 	}
 
 	public dynamic var location: Reference?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -541,6 +576,7 @@ open class EncounterLocation: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -579,8 +615,11 @@ open class EncounterParticipant: BackboneElement {
 	}
 
 	public dynamic var individual: Reference?
+	
 	public dynamic var period: Period?
+	
 	public let type = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -649,7 +688,9 @@ open class EncounterStatusHistory: BackboneElement {
 	}
 
 	public dynamic var period: Period?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -678,6 +719,7 @@ open class EncounterStatusHistory: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/EnrollmentRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/EnrollmentRequest.swift
@@ -2,7 +2,7 @@
 //  EnrollmentRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class EnrollmentRequest: DomainResource {
 	}
 
 	public dynamic var coverage: Reference?
+	
 	public dynamic var created: DateTime?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var relationship: Coding?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/EnrollmentResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/EnrollmentResponse.swift
@@ -2,7 +2,7 @@
 //  EnrollmentResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class EnrollmentResponse: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public dynamic var disposition: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var outcome: String?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var requestOrganization: Reference?
+	
 	public dynamic var requestProvider: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -48,6 +58,7 @@ open class EnrollmentResponse: DomainResource {
 				presentKeys.insert("disposition")
 				if let val = exist as? String {
 					self.disposition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "disposition", wants: String.self, has: type(of: exist)))
@@ -86,6 +97,7 @@ open class EnrollmentResponse: DomainResource {
 				presentKeys.insert("outcome")
 				if let val = exist as? String {
 					self.outcome = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcome", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/EpisodeOfCare.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/EpisodeOfCare.swift
@@ -2,7 +2,7 @@
 //  EpisodeOfCare.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EpisodeOfCare) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EpisodeOfCare) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,16 +23,27 @@ open class EpisodeOfCare: DomainResource {
 	}
 
 	public dynamic var careManager: Reference?
+	
 	public let careTeam = RealmSwift.List<EpisodeOfCareCareTeam>()
+	
 	public let condition = RealmSwift.List<Reference>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var managingOrganization: Reference?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var period: Period?
+	
 	public let referralRequest = RealmSwift.List<Reference>()
+	
 	public dynamic var status: String?
+	
 	public let statusHistory = RealmSwift.List<EpisodeOfCareStatusHistory>()
+	
 	public let type = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -132,6 +143,7 @@ open class EpisodeOfCare: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -219,8 +231,11 @@ open class EpisodeOfCareCareTeam: BackboneElement {
 	}
 
 	public dynamic var member: Reference?
+	
 	public dynamic var period: Period?
+	
 	public let role = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -289,7 +304,9 @@ open class EpisodeOfCareStatusHistory: BackboneElement {
 	}
 
 	public dynamic var period: Period?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -318,6 +335,7 @@ open class EpisodeOfCareStatusHistory: BackboneElement {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ExplanationOfBenefit.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ExplanationOfBenefit.swift
@@ -2,7 +2,7 @@
 //  ExplanationOfBenefit.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,15 +22,25 @@ open class ExplanationOfBenefit: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public dynamic var disposition: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var outcome: String?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var requestOrganization: Reference?
+	
 	public dynamic var requestProvider: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -49,6 +59,7 @@ open class ExplanationOfBenefit: DomainResource {
 				presentKeys.insert("disposition")
 				if let val = exist as? String {
 					self.disposition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "disposition", wants: String.self, has: type(of: exist)))
@@ -87,6 +98,7 @@ open class ExplanationOfBenefit: DomainResource {
 				presentKeys.insert("outcome")
 				if let val = exist as? String {
 					self.outcome = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcome", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Extension.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Extension.swift
@@ -2,7 +2,7 @@
 //  Extension.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Extension) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Extension) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,39 +21,73 @@ open class Extension: Element {
 	}
 
 	public dynamic var url: String?
+	
 	public dynamic var valueAddress: Address?
+	
 	public dynamic var valueAnnotation: Annotation?
+	
 	public dynamic var valueAttachment: Attachment?
+	
 	public dynamic var valueBase64Binary: Base64Binary?
+	
 	public let valueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var valueCode: String?
+	
 	public dynamic var valueCodeableConcept: CodeableConcept?
+	
 	public dynamic var valueCoding: Coding?
+	
 	public dynamic var valueContactPoint: ContactPoint?
+	
 	public dynamic var valueDate: FHIRDate?
+	
 	public dynamic var valueDateTime: DateTime?
+	
 	public dynamic var valueDecimal: RealmDecimal?
+	
 	public dynamic var valueHumanName: HumanName?
+	
 	public dynamic var valueId: String?
+	
 	public dynamic var valueIdentifier: Identifier?
+	
 	public dynamic var valueInstant: Instant?
+	
 	public let valueInteger = RealmOptional<Int>()
+	
 	public dynamic var valueMarkdown: String?
+	
 	public dynamic var valueMeta: Meta?
+	
 	public dynamic var valueOid: String?
+	
 	public dynamic var valuePeriod: Period?
+	
 	public let valuePositiveInt = RealmOptional<Int>()
+	
 	public dynamic var valueQuantity: Quantity?
+	
 	public dynamic var valueRange: Range?
+	
 	public dynamic var valueRatio: Ratio?
+	
 	public dynamic var valueReference: Reference?
+	
 	public dynamic var valueSampledData: SampledData?
+	
 	public dynamic var valueSignature: Signature?
+	
 	public dynamic var valueString: String?
+	
 	public dynamic var valueTime: FHIRTime?
+	
 	public dynamic var valueTiming: Timing?
+	
 	public let valueUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var valueUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -69,6 +103,7 @@ open class Extension: Element {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -117,6 +152,7 @@ open class Extension: Element {
 				presentKeys.insert("valueBoolean")
 				if let val = exist as? Bool {
 					self.valueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -126,6 +162,7 @@ open class Extension: Element {
 				presentKeys.insert("valueCode")
 				if let val = exist as? String {
 					self.valueCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueCode", wants: String.self, has: type(of: exist)))
@@ -198,6 +235,7 @@ open class Extension: Element {
 				presentKeys.insert("valueId")
 				if let val = exist as? String {
 					self.valueId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueId", wants: String.self, has: type(of: exist)))
@@ -225,6 +263,7 @@ open class Extension: Element {
 				presentKeys.insert("valueInteger")
 				if let val = exist as? Int {
 					self.valueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueInteger", wants: Int.self, has: type(of: exist)))
@@ -234,6 +273,7 @@ open class Extension: Element {
 				presentKeys.insert("valueMarkdown")
 				if let val = exist as? String {
 					self.valueMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueMarkdown", wants: String.self, has: type(of: exist)))
@@ -252,6 +292,7 @@ open class Extension: Element {
 				presentKeys.insert("valueOid")
 				if let val = exist as? String {
 					self.valueOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueOid", wants: String.self, has: type(of: exist)))
@@ -270,6 +311,7 @@ open class Extension: Element {
 				presentKeys.insert("valuePositiveInt")
 				if let val = exist as? Int {
 					self.valuePositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valuePositiveInt", wants: Int.self, has: type(of: exist)))
@@ -333,6 +375,7 @@ open class Extension: Element {
 				presentKeys.insert("valueString")
 				if let val = exist as? String {
 					self.valueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueString", wants: String.self, has: type(of: exist)))
@@ -360,6 +403,7 @@ open class Extension: Element {
 				presentKeys.insert("valueUnsignedInt")
 				if let val = exist as? Int {
 					self.valueUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -369,6 +413,7 @@ open class Extension: Element {
 				presentKeys.insert("valueUri")
 				if let val = exist as? String {
 					self.valueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueUri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/FHIRAbstractBase+Factory.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/FHIRAbstractBase+Factory.swift
@@ -2,7 +2,7 @@
 //  FHIRAbstractBase+Factory.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/FamilyMemberHistory.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/FamilyMemberHistory.swift
@@ -2,7 +2,7 @@
 //  FamilyMemberHistory.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,25 +22,45 @@ open class FamilyMemberHistory: DomainResource {
 	}
 
 	public dynamic var ageQuantity: Quantity?
+	
 	public dynamic var ageRange: Range?
+	
 	public dynamic var ageString: String?
+	
 	public dynamic var bornDate: FHIRDate?
+	
 	public dynamic var bornPeriod: Period?
+	
 	public dynamic var bornString: String?
+	
 	public let condition = RealmSwift.List<FamilyMemberHistoryCondition>()
+	
 	public dynamic var date: DateTime?
+	
 	public let deceasedBoolean = RealmOptional<Bool>()
+	
 	public dynamic var deceasedDate: FHIRDate?
+	
 	public dynamic var deceasedQuantity: Quantity?
+	
 	public dynamic var deceasedRange: Range?
+	
 	public dynamic var deceasedString: String?
+	
 	public dynamic var gender: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var note: Annotation?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var relationship: CodeableConcept?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -76,6 +96,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("ageString")
 				if let val = exist as? String {
 					self.ageString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "ageString", wants: String.self, has: type(of: exist)))
@@ -103,6 +124,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("bornString")
 				if let val = exist as? String {
 					self.bornString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "bornString", wants: String.self, has: type(of: exist)))
@@ -132,6 +154,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("deceasedBoolean")
 				if let val = exist as? Bool {
 					self.deceasedBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "deceasedBoolean", wants: Bool.self, has: type(of: exist)))
@@ -168,6 +191,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("deceasedString")
 				if let val = exist as? String {
 					self.deceasedString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "deceasedString", wants: String.self, has: type(of: exist)))
@@ -177,6 +201,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("gender")
 				if let val = exist as? String {
 					self.gender = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "gender", wants: String.self, has: type(of: exist)))
@@ -197,6 +222,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -239,6 +265,7 @@ open class FamilyMemberHistory: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -333,12 +360,19 @@ open class FamilyMemberHistoryCondition: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var note: Annotation?
+	
 	public dynamic var onsetPeriod: Period?
+	
 	public dynamic var onsetQuantity: Quantity?
+	
 	public dynamic var onsetRange: Range?
+	
 	public dynamic var onsetString: String?
+	
 	public dynamic var outcome: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -402,6 +436,7 @@ open class FamilyMemberHistoryCondition: BackboneElement {
 				presentKeys.insert("onsetString")
 				if let val = exist as? String {
 					self.onsetString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "onsetString", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Flag.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Flag.swift
@@ -2,7 +2,7 @@
 //  Flag.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Flag) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Flag) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,13 +21,21 @@ open class Flag: DomainResource {
 	}
 
 	public dynamic var author: Reference?
+	
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var period: Period?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -104,6 +112,7 @@ open class Flag: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Goal.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Goal.swift
@@ -2,7 +2,7 @@
 //  Goal.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Goal) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Goal) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,21 +22,37 @@ open class Goal: DomainResource {
 	}
 
 	public let addresses = RealmSwift.List<Reference>()
+	
 	public dynamic var author: Reference?
+	
 	public let category = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let note = RealmSwift.List<Annotation>()
+	
 	public let outcome = RealmSwift.List<GoalOutcome>()
+	
 	public dynamic var priority: CodeableConcept?
+	
 	public dynamic var startCodeableConcept: CodeableConcept?
+	
 	public dynamic var startDate: FHIRDate?
+	
 	public dynamic var status: String?
+	
 	public dynamic var statusDate: FHIRDate?
+	
 	public dynamic var statusReason: CodeableConcept?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var targetDate: FHIRDate?
+	
 	public dynamic var targetQuantity: Quantity?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -84,6 +100,7 @@ open class Goal: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -156,6 +173,7 @@ open class Goal: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -281,7 +299,9 @@ open class GoalOutcome: BackboneElement {
 	}
 
 	public dynamic var resultCodeableConcept: CodeableConcept?
+	
 	public dynamic var resultReference: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Group.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Group.swift
@@ -2,7 +2,7 @@
 //  Group.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Group) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Group) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,13 +23,21 @@ open class Group: DomainResource {
 	}
 
 	public let actual = RealmOptional<Bool>()
+	
 	public let characteristic = RealmSwift.List<GroupCharacteristic>()
+	
 	public dynamic var code: CodeableConcept?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let member = RealmSwift.List<GroupMember>()
+	
 	public dynamic var name: String?
+	
 	public let quantity = RealmOptional<Int>()
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -46,6 +54,7 @@ open class Group: DomainResource {
 				presentKeys.insert("actual")
 				if let val = exist as? Bool {
 					self.actual.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "actual", wants: Bool.self, has: type(of: exist)))
@@ -100,6 +109,7 @@ open class Group: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -109,6 +119,7 @@ open class Group: DomainResource {
 				presentKeys.insert("quantity")
 				if let val = exist as? Int {
 					self.quantity.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "quantity", wants: Int.self, has: type(of: exist)))
@@ -118,6 +129,7 @@ open class Group: DomainResource {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -174,12 +186,19 @@ open class GroupCharacteristic: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public let exclude = RealmOptional<Bool>()
+	
 	public dynamic var period: Period?
+	
 	public let valueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var valueCodeableConcept: CodeableConcept?
+	
 	public dynamic var valueQuantity: Quantity?
+	
 	public dynamic var valueRange: Range?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -212,6 +231,7 @@ open class GroupCharacteristic: BackboneElement {
 				presentKeys.insert("exclude")
 				if let val = exist as? Bool {
 					self.exclude.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "exclude", wants: Bool.self, has: type(of: exist)))
@@ -233,6 +253,7 @@ open class GroupCharacteristic: BackboneElement {
 				presentKeys.insert("valueBoolean")
 				if let val = exist as? Bool {
 					self.valueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -315,8 +336,11 @@ open class GroupMember: BackboneElement {
 	}
 
 	public dynamic var entity: Reference?
+	
 	public let inactive = RealmOptional<Bool>()
+	
 	public dynamic var period: Period?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -344,6 +368,7 @@ open class GroupMember: BackboneElement {
 				presentKeys.insert("inactive")
 				if let val = exist as? Bool {
 					self.inactive.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "inactive", wants: Bool.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/HealthcareService.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/HealthcareService.swift
@@ -2,7 +2,7 @@
 //  HealthcareService.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HealthcareService) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HealthcareService) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,27 +19,49 @@ open class HealthcareService: DomainResource {
 	}
 
 	public let appointmentRequired = RealmOptional<Bool>()
+	
 	public dynamic var availabilityExceptions: String?
+	
 	public let availableTime = RealmSwift.List<HealthcareServiceAvailableTime>()
+	
 	public let characteristic = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var comment: String?
+	
 	public let coverageArea = RealmSwift.List<Reference>()
+	
 	public dynamic var eligibility: CodeableConcept?
+	
 	public dynamic var eligibilityNote: String?
+	
 	public dynamic var extraDetails: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var location: Reference?
+	
 	public let notAvailable = RealmSwift.List<HealthcareServiceNotAvailable>()
+	
 	public dynamic var photo: Attachment?
+	
 	public let programName = RealmSwift.List<RealmString>()
+	
 	public dynamic var providedBy: Reference?
+	
 	public dynamic var publicKey: String?
+	
 	public let referralMethod = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var serviceCategory: CodeableConcept?
+	
 	public dynamic var serviceName: String?
+	
 	public let serviceProvisionCode = RealmSwift.List<CodeableConcept>()
+	
 	public let serviceType = RealmSwift.List<HealthcareServiceServiceType>()
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -55,6 +77,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("appointmentRequired")
 				if let val = exist as? Bool {
 					self.appointmentRequired.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "appointmentRequired", wants: Bool.self, has: type(of: exist)))
@@ -64,6 +87,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("availabilityExceptions")
 				if let val = exist as? String {
 					self.availabilityExceptions = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "availabilityExceptions", wants: String.self, has: type(of: exist)))
@@ -95,6 +119,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("comment")
 				if let val = exist as? String {
 					self.comment = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comment", wants: String.self, has: type(of: exist)))
@@ -124,6 +149,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("eligibilityNote")
 				if let val = exist as? String {
 					self.eligibilityNote = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "eligibilityNote", wants: String.self, has: type(of: exist)))
@@ -133,6 +159,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("extraDetails")
 				if let val = exist as? String {
 					self.extraDetails = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "extraDetails", wants: String.self, has: type(of: exist)))
@@ -203,6 +230,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("publicKey")
 				if let val = exist as? String {
 					self.publicKey = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publicKey", wants: String.self, has: type(of: exist)))
@@ -232,6 +260,7 @@ open class HealthcareService: DomainResource {
 				presentKeys.insert("serviceName")
 				if let val = exist as? String {
 					self.serviceName = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "serviceName", wants: String.self, has: type(of: exist)))
@@ -360,9 +389,13 @@ open class HealthcareServiceAvailableTime: BackboneElement {
 	}
 
 	public let allDay = RealmOptional<Bool>()
+	
 	public dynamic var availableEndTime: FHIRTime?
+	
 	public dynamic var availableStartTime: FHIRTime?
+	
 	public let daysOfWeek = RealmSwift.List<RealmString>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -372,6 +405,7 @@ open class HealthcareServiceAvailableTime: BackboneElement {
 				presentKeys.insert("allDay")
 				if let val = exist as? Bool {
 					self.allDay.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "allDay", wants: Bool.self, has: type(of: exist)))
@@ -440,7 +474,9 @@ open class HealthcareServiceNotAvailable: BackboneElement {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public dynamic var during: Period?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -456,6 +492,7 @@ open class HealthcareServiceNotAvailable: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -503,7 +540,9 @@ open class HealthcareServiceServiceType: BackboneElement {
 	}
 
 	public let specialty = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/HumanName.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/HumanName.swift
@@ -2,7 +2,7 @@
 //  HumanName.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HumanName) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HumanName) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,12 +21,19 @@ open class HumanName: Element {
 	}
 
 	public let family = RealmSwift.List<RealmString>()
+	
 	public let given = RealmSwift.List<RealmString>()
+	
 	public dynamic var period: Period?
+	
 	public let prefix = RealmSwift.List<RealmString>()
+	
 	public let suffix = RealmSwift.List<RealmString>()
+	
 	public dynamic var text: String?
+	
 	public dynamic var use: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -81,6 +88,7 @@ open class HumanName: Element {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -90,6 +98,7 @@ open class HumanName: Element {
 				presentKeys.insert("use")
 				if let val = exist as? String {
 					self.use = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "use", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Identifier.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Identifier.swift
@@ -2,7 +2,7 @@
 //  Identifier.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Identifier) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Identifier) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,11 +21,17 @@ open class Identifier: Element {
 	}
 
 	public dynamic var assigner: Reference?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var system: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public dynamic var use: String?
+	
 	public dynamic var value: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -53,6 +59,7 @@ open class Identifier: Element {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -71,6 +78,7 @@ open class Identifier: Element {
 				presentKeys.insert("use")
 				if let val = exist as? String {
 					self.use = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "use", wants: String.self, has: type(of: exist)))
@@ -80,6 +88,7 @@ open class Identifier: Element {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ImagingObjectSelection.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ImagingObjectSelection.swift
@@ -2,7 +2,7 @@
 //  ImagingObjectSelection.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingObjectSelection) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingObjectSelection) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -27,12 +27,19 @@ open class ImagingObjectSelection: DomainResource {
 	}
 
 	public dynamic var author: Reference?
+	
 	public dynamic var authoringTime: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var patient: Reference?
+	
 	public let study = RealmSwift.List<ImagingObjectSelectionStudy>()
+	
 	public dynamic var title: CodeableConcept?
+	
 	public dynamic var uid: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -69,6 +76,7 @@ open class ImagingObjectSelection: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -116,6 +124,7 @@ open class ImagingObjectSelection: DomainResource {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))
@@ -169,9 +178,13 @@ open class ImagingObjectSelectionStudy: BackboneElement {
 	}
 
 	public dynamic var imagingStudy: Reference?
+	
 	public let series = RealmSwift.List<ImagingObjectSelectionStudySeries>()
+	
 	public dynamic var uid: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -211,6 +224,7 @@ open class ImagingObjectSelectionStudy: BackboneElement {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))
@@ -223,6 +237,7 @@ open class ImagingObjectSelectionStudy: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -264,8 +279,11 @@ open class ImagingObjectSelectionStudySeries: BackboneElement {
 	}
 
 	public let instance = RealmSwift.List<ImagingObjectSelectionStudySeriesInstance>()
+	
 	public dynamic var uid: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -295,6 +313,7 @@ open class ImagingObjectSelectionStudySeries: BackboneElement {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))
@@ -304,6 +323,7 @@ open class ImagingObjectSelectionStudySeries: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -342,9 +362,13 @@ open class ImagingObjectSelectionStudySeriesInstance: BackboneElement {
 	}
 
 	public let frames = RealmSwift.List<ImagingObjectSelectionStudySeriesInstanceFrames>()
+	
 	public dynamic var sopClass: String?
+	
 	public dynamic var uid: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -373,6 +397,7 @@ open class ImagingObjectSelectionStudySeriesInstance: BackboneElement {
 				presentKeys.insert("sopClass")
 				if let val = exist as? String {
 					self.sopClass = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sopClass", wants: String.self, has: type(of: exist)))
@@ -385,6 +410,7 @@ open class ImagingObjectSelectionStudySeriesInstance: BackboneElement {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))
@@ -397,6 +423,7 @@ open class ImagingObjectSelectionStudySeriesInstance: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -441,7 +468,9 @@ open class ImagingObjectSelectionStudySeriesInstanceFrames: BackboneElement {
 	}
 
 	public let frameNumbers = RealmSwift.List<RealmInt>()
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -470,6 +499,7 @@ open class ImagingObjectSelectionStudySeriesInstanceFrames: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ImagingStudy.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ImagingStudy.swift
@@ -2,7 +2,7 @@
 //  ImagingStudy.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingStudy) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingStudy) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -24,21 +24,37 @@ open class ImagingStudy: DomainResource {
 	}
 
 	public dynamic var accession: Identifier?
+	
 	public dynamic var availability: String?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var interpreter: Reference?
+	
 	public let modalityList = RealmSwift.List<Coding>()
+	
 	public let numberOfInstances = RealmOptional<Int>()
+	
 	public let numberOfSeries = RealmOptional<Int>()
+	
 	public let order = RealmSwift.List<Reference>()
+	
 	public dynamic var patient: Reference?
+	
 	public let procedure = RealmSwift.List<Reference>()
+	
 	public dynamic var referrer: Reference?
+	
 	public let series = RealmSwift.List<ImagingStudySeries>()
+	
 	public dynamic var started: DateTime?
+	
 	public dynamic var uid: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -66,6 +82,7 @@ open class ImagingStudy: DomainResource {
 				presentKeys.insert("availability")
 				if let val = exist as? String {
 					self.availability = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "availability", wants: String.self, has: type(of: exist)))
@@ -75,6 +92,7 @@ open class ImagingStudy: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -115,6 +133,7 @@ open class ImagingStudy: DomainResource {
 				presentKeys.insert("numberOfInstances")
 				if let val = exist as? Int {
 					self.numberOfInstances.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "numberOfInstances", wants: Int.self, has: type(of: exist)))
@@ -127,6 +146,7 @@ open class ImagingStudy: DomainResource {
 				presentKeys.insert("numberOfSeries")
 				if let val = exist as? Int {
 					self.numberOfSeries.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "numberOfSeries", wants: Int.self, has: type(of: exist)))
@@ -202,6 +222,7 @@ open class ImagingStudy: DomainResource {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))
@@ -214,6 +235,7 @@ open class ImagingStudy: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -291,16 +313,27 @@ open class ImagingStudySeries: BackboneElement {
 	}
 
 	public dynamic var availability: String?
+	
 	public dynamic var bodySite: Coding?
+	
 	public dynamic var description_fhir: String?
+	
 	public let instance = RealmSwift.List<ImagingStudySeriesInstance>()
+	
 	public dynamic var laterality: Coding?
+	
 	public dynamic var modality: Coding?
+	
 	public let number = RealmOptional<Int>()
+	
 	public let numberOfInstances = RealmOptional<Int>()
+	
 	public dynamic var started: DateTime?
+	
 	public dynamic var uid: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -318,6 +351,7 @@ open class ImagingStudySeries: BackboneElement {
 				presentKeys.insert("availability")
 				if let val = exist as? String {
 					self.availability = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "availability", wants: String.self, has: type(of: exist)))
@@ -336,6 +370,7 @@ open class ImagingStudySeries: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -377,6 +412,7 @@ open class ImagingStudySeries: BackboneElement {
 				presentKeys.insert("number")
 				if let val = exist as? Int {
 					self.number.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "number", wants: Int.self, has: type(of: exist)))
@@ -386,6 +422,7 @@ open class ImagingStudySeries: BackboneElement {
 				presentKeys.insert("numberOfInstances")
 				if let val = exist as? Int {
 					self.numberOfInstances.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "numberOfInstances", wants: Int.self, has: type(of: exist)))
@@ -407,6 +444,7 @@ open class ImagingStudySeries: BackboneElement {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))
@@ -419,6 +457,7 @@ open class ImagingStudySeries: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -481,11 +520,17 @@ open class ImagingStudySeriesInstance: BackboneElement {
 	}
 
 	public let content = RealmSwift.List<Attachment>()
+	
 	public let number = RealmOptional<Int>()
+	
 	public dynamic var sopClass: String?
+	
 	public dynamic var title: String?
+	
 	public dynamic var type: String?
+	
 	public dynamic var uid: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -513,6 +558,7 @@ open class ImagingStudySeriesInstance: BackboneElement {
 				presentKeys.insert("number")
 				if let val = exist as? Int {
 					self.number.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "number", wants: Int.self, has: type(of: exist)))
@@ -522,6 +568,7 @@ open class ImagingStudySeriesInstance: BackboneElement {
 				presentKeys.insert("sopClass")
 				if let val = exist as? String {
 					self.sopClass = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sopClass", wants: String.self, has: type(of: exist)))
@@ -534,6 +581,7 @@ open class ImagingStudySeriesInstance: BackboneElement {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))
@@ -543,6 +591,7 @@ open class ImagingStudySeriesInstance: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -552,6 +601,7 @@ open class ImagingStudySeriesInstance: BackboneElement {
 				presentKeys.insert("uid")
 				if let val = exist as? String {
 					self.uid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uid", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Immunization.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Immunization.swift
@@ -2,7 +2,7 @@
 //  Immunization.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Immunization) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Immunization) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,26 +23,47 @@ open class Immunization: DomainResource {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public dynamic var doseQuantity: Quantity?
+	
 	public dynamic var encounter: Reference?
+	
 	public dynamic var expirationDate: FHIRDate?
+	
 	public dynamic var explanation: ImmunizationExplanation?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var location: Reference?
+	
 	public dynamic var lotNumber: String?
+	
 	public dynamic var manufacturer: Reference?
+	
 	public let note = RealmSwift.List<Annotation>()
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var performer: Reference?
+	
 	public let reaction = RealmSwift.List<ImmunizationReaction>()
+	
 	public let reported = RealmOptional<Bool>()
+	
 	public dynamic var requester: Reference?
+	
 	public dynamic var route: CodeableConcept?
+	
 	public dynamic var site: CodeableConcept?
+	
 	public dynamic var status: String?
+	
 	public let vaccinationProtocol = RealmSwift.List<ImmunizationVaccinationProtocol>()
+	
 	public dynamic var vaccineCode: CodeableConcept?
+	
 	public let wasNotGiven = RealmOptional<Bool>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -127,6 +148,7 @@ open class Immunization: DomainResource {
 				presentKeys.insert("lotNumber")
 				if let val = exist as? String {
 					self.lotNumber = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "lotNumber", wants: String.self, has: type(of: exist)))
@@ -188,6 +210,7 @@ open class Immunization: DomainResource {
 				presentKeys.insert("reported")
 				if let val = exist as? Bool {
 					self.reported.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reported", wants: Bool.self, has: type(of: exist)))
@@ -227,6 +250,7 @@ open class Immunization: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -262,6 +286,7 @@ open class Immunization: DomainResource {
 				presentKeys.insert("wasNotGiven")
 				if let val = exist as? Bool {
 					self.wasNotGiven.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "wasNotGiven", wants: Bool.self, has: type(of: exist)))
@@ -357,7 +382,9 @@ open class ImmunizationExplanation: BackboneElement {
 	}
 
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public let reasonNotGiven = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -415,8 +442,11 @@ open class ImmunizationReaction: BackboneElement {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public dynamic var detail: Reference?
+	
 	public let reported = RealmOptional<Bool>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -444,6 +474,7 @@ open class ImmunizationReaction: BackboneElement {
 				presentKeys.insert("reported")
 				if let val = exist as? Bool {
 					self.reported.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reported", wants: Bool.self, has: type(of: exist)))
@@ -482,13 +513,21 @@ open class ImmunizationVaccinationProtocol: BackboneElement {
 	}
 
 	public dynamic var authority: Reference?
+	
 	public dynamic var description_fhir: String?
+	
 	public let doseSequence = RealmOptional<Int>()
+	
 	public dynamic var doseStatus: CodeableConcept?
+	
 	public dynamic var doseStatusReason: CodeableConcept?
+	
 	public dynamic var series: String?
+	
 	public let seriesDoses = RealmOptional<Int>()
+	
 	public let targetDisease = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -515,6 +554,7 @@ open class ImmunizationVaccinationProtocol: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -524,6 +564,7 @@ open class ImmunizationVaccinationProtocol: BackboneElement {
 				presentKeys.insert("doseSequence")
 				if let val = exist as? Int {
 					self.doseSequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "doseSequence", wants: Int.self, has: type(of: exist)))
@@ -557,6 +598,7 @@ open class ImmunizationVaccinationProtocol: BackboneElement {
 				presentKeys.insert("series")
 				if let val = exist as? String {
 					self.series = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "series", wants: String.self, has: type(of: exist)))
@@ -566,6 +608,7 @@ open class ImmunizationVaccinationProtocol: BackboneElement {
 				presentKeys.insert("seriesDoses")
 				if let val = exist as? Int {
 					self.seriesDoses.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "seriesDoses", wants: Int.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ImmunizationRecommendation.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ImmunizationRecommendation.swift
@@ -2,7 +2,7 @@
 //  ImmunizationRecommendation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,8 +22,11 @@ open class ImmunizationRecommendation: DomainResource {
 	}
 
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var patient: Reference?
+	
 	public let recommendation = RealmSwift.List<ImmunizationRecommendationRecommendation>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -104,13 +107,21 @@ open class ImmunizationRecommendationRecommendation: BackboneElement {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public let dateCriterion = RealmSwift.List<ImmunizationRecommendationRecommendationDateCriterion>()
+	
 	public let doseNumber = RealmOptional<Int>()
+	
 	public dynamic var forecastStatus: CodeableConcept?
+	
 	public dynamic var protocol_fhir: ImmunizationRecommendationRecommendationProtocol?
+	
 	public let supportingImmunization = RealmSwift.List<Reference>()
+	
 	public let supportingPatientInformation = RealmSwift.List<Reference>()
+	
 	public dynamic var vaccineCode: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -151,6 +162,7 @@ open class ImmunizationRecommendationRecommendation: BackboneElement {
 				presentKeys.insert("doseNumber")
 				if let val = exist as? Int {
 					self.doseNumber.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "doseNumber", wants: Int.self, has: type(of: exist)))
@@ -259,7 +271,9 @@ open class ImmunizationRecommendationRecommendationDateCriterion: BackboneElemen
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var value: DateTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -326,9 +340,13 @@ open class ImmunizationRecommendationRecommendationProtocol: BackboneElement {
 	}
 
 	public dynamic var authority: Reference?
+	
 	public dynamic var description_fhir: String?
+	
 	public let doseSequence = RealmOptional<Int>()
+	
 	public dynamic var series: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -347,6 +365,7 @@ open class ImmunizationRecommendationRecommendationProtocol: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -356,6 +375,7 @@ open class ImmunizationRecommendationRecommendationProtocol: BackboneElement {
 				presentKeys.insert("doseSequence")
 				if let val = exist as? Int {
 					self.doseSequence.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "doseSequence", wants: Int.self, has: type(of: exist)))
@@ -365,6 +385,7 @@ open class ImmunizationRecommendationRecommendationProtocol: BackboneElement {
 				presentKeys.insert("series")
 				if let val = exist as? String {
 					self.series = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "series", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ImplementationGuide.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ImplementationGuide.swift
@@ -2,7 +2,7 @@
 //  ImplementationGuide.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImplementationGuide) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImplementationGuide) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,22 +22,39 @@ open class ImplementationGuide: DomainResource {
 	}
 
 	public let binary = RealmSwift.List<RealmString>()
+	
 	public let contact = RealmSwift.List<ImplementationGuideContact>()
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public let dependency = RealmSwift.List<ImplementationGuideDependency>()
+	
 	public dynamic var description_fhir: String?
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public dynamic var fhirVersion: String?
+	
 	public let global = RealmSwift.List<ImplementationGuideGlobal>()
+	
 	public dynamic var name: String?
+	
 	public let package = RealmSwift.List<ImplementationGuidePackage>()
+	
 	public dynamic var page: ImplementationGuidePage?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var status: String?
+	
 	public dynamic var url: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -77,6 +94,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -106,6 +124,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -115,6 +134,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -124,6 +144,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("fhirVersion")
 				if let val = exist as? String {
 					self.fhirVersion = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fhirVersion", wants: String.self, has: type(of: exist)))
@@ -144,6 +165,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -182,6 +204,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -191,6 +214,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -203,6 +227,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -226,6 +251,7 @@ open class ImplementationGuide: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -306,7 +332,9 @@ open class ImplementationGuideContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -316,6 +344,7 @@ open class ImplementationGuideContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -363,7 +392,9 @@ open class ImplementationGuideDependency: BackboneElement {
 	}
 
 	public dynamic var type: String?
+	
 	public dynamic var uri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -380,6 +411,7 @@ open class ImplementationGuideDependency: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -392,6 +424,7 @@ open class ImplementationGuideDependency: BackboneElement {
 				presentKeys.insert("uri")
 				if let val = exist as? String {
 					self.uri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uri", wants: String.self, has: type(of: exist)))
@@ -430,7 +463,9 @@ open class ImplementationGuideGlobal: BackboneElement {
 	}
 
 	public dynamic var profile: Reference?
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -459,6 +494,7 @@ open class ImplementationGuideGlobal: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -497,8 +533,11 @@ open class ImplementationGuidePackage: BackboneElement {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public dynamic var name: String?
+	
 	public let resource = RealmSwift.List<ImplementationGuidePackageResource>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -515,6 +554,7 @@ open class ImplementationGuidePackage: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -524,6 +564,7 @@ open class ImplementationGuidePackage: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -581,12 +622,19 @@ open class ImplementationGuidePackageResource: BackboneElement {
 	}
 
 	public dynamic var acronym: String?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var exampleFor: Reference?
+	
 	public dynamic var name: String?
+	
 	public dynamic var purpose: String?
+	
 	public dynamic var sourceReference: Reference?
+	
 	public dynamic var sourceUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -604,6 +652,7 @@ open class ImplementationGuidePackageResource: BackboneElement {
 				presentKeys.insert("acronym")
 				if let val = exist as? String {
 					self.acronym = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "acronym", wants: String.self, has: type(of: exist)))
@@ -613,6 +662,7 @@ open class ImplementationGuidePackageResource: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -631,6 +681,7 @@ open class ImplementationGuidePackageResource: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -640,6 +691,7 @@ open class ImplementationGuidePackageResource: BackboneElement {
 				presentKeys.insert("purpose")
 				if let val = exist as? String {
 					self.purpose = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "purpose", wants: String.self, has: type(of: exist)))
@@ -661,6 +713,7 @@ open class ImplementationGuidePackageResource: BackboneElement {
 				presentKeys.insert("sourceUri")
 				if let val = exist as? String {
 					self.sourceUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sourceUri", wants: String.self, has: type(of: exist)))
@@ -716,12 +769,19 @@ open class ImplementationGuidePage: BackboneElement {
 	}
 
 	public dynamic var format: String?
+	
 	public dynamic var kind: String?
+	
 	public dynamic var name: String?
+	
 	public let package = RealmSwift.List<RealmString>()
+	
 	public let page = RealmSwift.List<ImplementationGuidePage>()
+	
 	public dynamic var source: String?
+	
 	public let type = RealmSwift.List<RealmString>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -739,6 +799,7 @@ open class ImplementationGuidePage: BackboneElement {
 				presentKeys.insert("format")
 				if let val = exist as? String {
 					self.format = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "format", wants: String.self, has: type(of: exist)))
@@ -748,6 +809,7 @@ open class ImplementationGuidePage: BackboneElement {
 				presentKeys.insert("kind")
 				if let val = exist as? String {
 					self.kind = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "kind", wants: String.self, has: type(of: exist)))
@@ -760,6 +822,7 @@ open class ImplementationGuidePage: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -792,6 +855,7 @@ open class ImplementationGuidePage: BackboneElement {
 				presentKeys.insert("source")
 				if let val = exist as? String {
 					self.source = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "source", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/List.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/List.swift
@@ -2,7 +2,7 @@
 //  List.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/List) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/List) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,18 +21,31 @@ open class List: DomainResource {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var emptyReason: CodeableConcept?
+	
 	public dynamic var encounter: Reference?
+	
 	public let entry = RealmSwift.List<ListEntry>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var mode: String?
+	
 	public dynamic var note: String?
+	
 	public dynamic var orderedBy: CodeableConcept?
+	
 	public dynamic var source: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var title: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -107,6 +120,7 @@ open class List: DomainResource {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -119,6 +133,7 @@ open class List: DomainResource {
 				presentKeys.insert("note")
 				if let val = exist as? String {
 					self.note = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "note", wants: String.self, has: type(of: exist)))
@@ -146,6 +161,7 @@ open class List: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -167,6 +183,7 @@ open class List: DomainResource {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))
@@ -235,9 +252,13 @@ open class ListEntry: BackboneElement {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public let deleted = RealmOptional<Bool>()
+	
 	public dynamic var flag: CodeableConcept?
+	
 	public dynamic var item: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -262,6 +283,7 @@ open class ListEntry: BackboneElement {
 				presentKeys.insert("deleted")
 				if let val = exist as? Bool {
 					self.deleted.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "deleted", wants: Bool.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Location.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Location.swift
@@ -2,7 +2,7 @@
 //  Location.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Location) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Location) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,17 +22,29 @@ open class Location: DomainResource {
 	}
 
 	public dynamic var address: Address?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var managingOrganization: Reference?
+	
 	public dynamic var mode: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var partOf: Reference?
+	
 	public dynamic var physicalType: CodeableConcept?
+	
 	public dynamic var position: LocationPosition?
+	
 	public dynamic var status: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -51,6 +63,7 @@ open class Location: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -80,6 +93,7 @@ open class Location: DomainResource {
 				presentKeys.insert("mode")
 				if let val = exist as? String {
 					self.mode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mode", wants: String.self, has: type(of: exist)))
@@ -89,6 +103,7 @@ open class Location: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -125,6 +140,7 @@ open class Location: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -211,8 +227,11 @@ open class LocationPosition: BackboneElement {
 	}
 
 	public dynamic var altitude: RealmDecimal?
+	
 	public dynamic var latitude: RealmDecimal?
+	
 	public dynamic var longitude: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Media.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Media.swift
@@ -2,7 +2,7 @@
 //  Media.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Media) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Media) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -20,17 +20,29 @@ open class Media: DomainResource {
 	}
 
 	public dynamic var content: Attachment?
+	
 	public dynamic var deviceName: String?
+	
 	public let duration = RealmOptional<Int>()
+	
 	public let frames = RealmOptional<Int>()
+	
 	public let height = RealmOptional<Int>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var operator_fhir: Reference?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var subtype: CodeableConcept?
+	
 	public dynamic var type: String?
+	
 	public dynamic var view: CodeableConcept?
+	
 	public let width = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -59,6 +71,7 @@ open class Media: DomainResource {
 				presentKeys.insert("deviceName")
 				if let val = exist as? String {
 					self.deviceName = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "deviceName", wants: String.self, has: type(of: exist)))
@@ -68,6 +81,7 @@ open class Media: DomainResource {
 				presentKeys.insert("duration")
 				if let val = exist as? Int {
 					self.duration.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "duration", wants: Int.self, has: type(of: exist)))
@@ -77,6 +91,7 @@ open class Media: DomainResource {
 				presentKeys.insert("frames")
 				if let val = exist as? Int {
 					self.frames.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "frames", wants: Int.self, has: type(of: exist)))
@@ -86,6 +101,7 @@ open class Media: DomainResource {
 				presentKeys.insert("height")
 				if let val = exist as? Int {
 					self.height.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "height", wants: Int.self, has: type(of: exist)))
@@ -133,6 +149,7 @@ open class Media: DomainResource {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -154,6 +171,7 @@ open class Media: DomainResource {
 				presentKeys.insert("width")
 				if let val = exist as? Int {
 					self.width.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "width", wants: Int.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Medication.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Medication.swift
@@ -2,7 +2,7 @@
 //  Medication.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Medication) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Medication) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,10 +22,15 @@ open class Medication: DomainResource {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public let isBrand = RealmOptional<Bool>()
+	
 	public dynamic var manufacturer: Reference?
+	
 	public dynamic var package: MedicationPackage?
+	
 	public dynamic var product: MedicationProduct?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -44,6 +49,7 @@ open class Medication: DomainResource {
 				presentKeys.insert("isBrand")
 				if let val = exist as? Bool {
 					self.isBrand.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "isBrand", wants: Bool.self, has: type(of: exist)))
@@ -115,7 +121,9 @@ open class MedicationPackage: BackboneElement {
 	}
 
 	public dynamic var container: CodeableConcept?
+	
 	public let content = RealmSwift.List<MedicationPackageContent>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -171,7 +179,9 @@ open class MedicationPackageContent: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var item: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -234,8 +244,11 @@ open class MedicationProduct: BackboneElement {
 	}
 
 	public let batch = RealmSwift.List<MedicationProductBatch>()
+	
 	public dynamic var form: CodeableConcept?
+	
 	public let ingredient = RealmSwift.List<MedicationProductIngredient>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -305,7 +318,9 @@ open class MedicationProductBatch: BackboneElement {
 	}
 
 	public dynamic var expirationDate: DateTime?
+	
 	public dynamic var lotNumber: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -324,6 +339,7 @@ open class MedicationProductBatch: BackboneElement {
 				presentKeys.insert("lotNumber")
 				if let val = exist as? String {
 					self.lotNumber = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "lotNumber", wants: String.self, has: type(of: exist)))
@@ -359,7 +375,9 @@ open class MedicationProductIngredient: BackboneElement {
 	}
 
 	public dynamic var amount: Ratio?
+	
 	public dynamic var item: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationAdministration.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationAdministration.swift
@@ -2,7 +2,7 @@
 //  MedicationAdministration.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationAdministration) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationAdministration) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,21 +23,37 @@ open class MedicationAdministration: DomainResource {
 	}
 
 	public let device = RealmSwift.List<Reference>()
+	
 	public dynamic var dosage: MedicationAdministrationDosage?
+	
 	public dynamic var effectiveTimeDateTime: DateTime?
+	
 	public dynamic var effectiveTimePeriod: Period?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var medicationCodeableConcept: CodeableConcept?
+	
 	public dynamic var medicationReference: Reference?
+	
 	public dynamic var note: String?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var practitioner: Reference?
+	
 	public dynamic var prescription: Reference?
+	
 	public let reasonGiven = RealmSwift.List<CodeableConcept>()
+	
 	public let reasonNotGiven = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var status: String?
+	
 	public let wasNotGiven = RealmOptional<Bool>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -134,6 +150,7 @@ open class MedicationAdministration: DomainResource {
 				presentKeys.insert("note")
 				if let val = exist as? String {
 					self.note = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "note", wants: String.self, has: type(of: exist)))
@@ -195,6 +212,7 @@ open class MedicationAdministration: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -207,6 +225,7 @@ open class MedicationAdministration: DomainResource {
 				presentKeys.insert("wasNotGiven")
 				if let val = exist as? Bool {
 					self.wasNotGiven.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "wasNotGiven", wants: Bool.self, has: type(of: exist)))
@@ -292,13 +311,21 @@ open class MedicationAdministrationDosage: BackboneElement {
 	}
 
 	public dynamic var method: CodeableConcept?
+	
 	public dynamic var quantity: Quantity?
+	
 	public dynamic var rateRange: Range?
+	
 	public dynamic var rateRatio: Ratio?
+	
 	public dynamic var route: CodeableConcept?
+	
 	public dynamic var siteCodeableConcept: CodeableConcept?
+	
 	public dynamic var siteReference: Reference?
+	
 	public dynamic var text: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -371,6 +398,7 @@ open class MedicationAdministrationDosage: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationDispense.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationDispense.swift
@@ -2,7 +2,7 @@
 //  MedicationDispense.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationDispense) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationDispense) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,22 +23,39 @@ open class MedicationDispense: DomainResource {
 	}
 
 	public let authorizingPrescription = RealmSwift.List<Reference>()
+	
 	public dynamic var daysSupply: Quantity?
+	
 	public dynamic var destination: Reference?
+	
 	public dynamic var dispenser: Reference?
+	
 	public let dosageInstruction = RealmSwift.List<MedicationDispenseDosageInstruction>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var medicationCodeableConcept: CodeableConcept?
+	
 	public dynamic var medicationReference: Reference?
+	
 	public dynamic var note: String?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var quantity: Quantity?
+	
 	public let receiver = RealmSwift.List<Reference>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var substitution: MedicationDispenseSubstitution?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public dynamic var whenHandedOver: DateTime?
+	
 	public dynamic var whenPrepared: DateTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -131,6 +148,7 @@ open class MedicationDispense: DomainResource {
 				presentKeys.insert("note")
 				if let val = exist as? String {
 					self.note = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "note", wants: String.self, has: type(of: exist)))
@@ -169,6 +187,7 @@ open class MedicationDispense: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -290,19 +309,33 @@ open class MedicationDispenseDosageInstruction: BackboneElement {
 	}
 
 	public dynamic var additionalInstructions: CodeableConcept?
+	
 	public let asNeededBoolean = RealmOptional<Bool>()
+	
 	public dynamic var asNeededCodeableConcept: CodeableConcept?
+	
 	public dynamic var doseQuantity: Quantity?
+	
 	public dynamic var doseRange: Range?
+	
 	public dynamic var maxDosePerPeriod: Ratio?
+	
 	public dynamic var method: CodeableConcept?
+	
 	public dynamic var rateRange: Range?
+	
 	public dynamic var rateRatio: Ratio?
+	
 	public dynamic var route: CodeableConcept?
+	
 	public dynamic var siteCodeableConcept: CodeableConcept?
+	
 	public dynamic var siteReference: Reference?
+	
 	public dynamic var text: String?
+	
 	public dynamic var timing: Timing?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -321,6 +354,7 @@ open class MedicationDispenseDosageInstruction: BackboneElement {
 				presentKeys.insert("asNeededBoolean")
 				if let val = exist as? Bool {
 					self.asNeededBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "asNeededBoolean", wants: Bool.self, has: type(of: exist)))
@@ -420,6 +454,7 @@ open class MedicationDispenseDosageInstruction: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -502,8 +537,11 @@ open class MedicationDispenseSubstitution: BackboneElement {
 	}
 
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public let responsibleParty = RealmSwift.List<Reference>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationOrder.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationOrder.swift
@@ -2,7 +2,7 @@
 //  MedicationOrder.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationOrder) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationOrder) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,22 +23,39 @@ open class MedicationOrder: DomainResource {
 	}
 
 	public dynamic var dateEnded: DateTime?
+	
 	public dynamic var dateWritten: DateTime?
+	
 	public dynamic var dispenseRequest: MedicationOrderDispenseRequest?
+	
 	public let dosageInstruction = RealmSwift.List<MedicationOrderDosageInstruction>()
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var medicationCodeableConcept: CodeableConcept?
+	
 	public dynamic var medicationReference: Reference?
+	
 	public dynamic var note: String?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var prescriber: Reference?
+	
 	public dynamic var priorPrescription: Reference?
+	
 	public dynamic var reasonCodeableConcept: CodeableConcept?
+	
 	public dynamic var reasonEnded: CodeableConcept?
+	
 	public dynamic var reasonReference: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var substitution: MedicationOrderSubstitution?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -131,6 +148,7 @@ open class MedicationOrder: DomainResource {
 				presentKeys.insert("note")
 				if let val = exist as? String {
 					self.note = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "note", wants: String.self, has: type(of: exist)))
@@ -194,6 +212,7 @@ open class MedicationOrder: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -291,11 +310,17 @@ open class MedicationOrderDispenseRequest: BackboneElement {
 	}
 
 	public dynamic var expectedSupplyDuration: Quantity?
+	
 	public dynamic var medicationCodeableConcept: CodeableConcept?
+	
 	public dynamic var medicationReference: Reference?
+	
 	public let numberOfRepeatsAllowed = RealmOptional<Int>()
+	
 	public dynamic var quantity: Quantity?
+	
 	public dynamic var validityPeriod: Period?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -332,6 +357,7 @@ open class MedicationOrderDispenseRequest: BackboneElement {
 				presentKeys.insert("numberOfRepeatsAllowed")
 				if let val = exist as? Int {
 					self.numberOfRepeatsAllowed.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "numberOfRepeatsAllowed", wants: Int.self, has: type(of: exist)))
@@ -397,19 +423,33 @@ open class MedicationOrderDosageInstruction: BackboneElement {
 	}
 
 	public dynamic var additionalInstructions: CodeableConcept?
+	
 	public let asNeededBoolean = RealmOptional<Bool>()
+	
 	public dynamic var asNeededCodeableConcept: CodeableConcept?
+	
 	public dynamic var doseQuantity: Quantity?
+	
 	public dynamic var doseRange: Range?
+	
 	public dynamic var maxDosePerPeriod: Ratio?
+	
 	public dynamic var method: CodeableConcept?
+	
 	public dynamic var rateRange: Range?
+	
 	public dynamic var rateRatio: Ratio?
+	
 	public dynamic var route: CodeableConcept?
+	
 	public dynamic var siteCodeableConcept: CodeableConcept?
+	
 	public dynamic var siteReference: Reference?
+	
 	public dynamic var text: String?
+	
 	public dynamic var timing: Timing?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -428,6 +468,7 @@ open class MedicationOrderDosageInstruction: BackboneElement {
 				presentKeys.insert("asNeededBoolean")
 				if let val = exist as? Bool {
 					self.asNeededBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "asNeededBoolean", wants: Bool.self, has: type(of: exist)))
@@ -527,6 +568,7 @@ open class MedicationOrderDosageInstruction: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -609,7 +651,9 @@ open class MedicationOrderSubstitution: BackboneElement {
 	}
 
 	public dynamic var reason: CodeableConcept?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationStatement.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/MedicationStatement.swift
@@ -2,7 +2,7 @@
 //  MedicationStatement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationStatement) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationStatement) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -34,21 +34,37 @@ open class MedicationStatement: DomainResource {
 	}
 
 	public dynamic var dateAsserted: DateTime?
+	
 	public let dosage = RealmSwift.List<MedicationStatementDosage>()
+	
 	public dynamic var effectiveDateTime: DateTime?
+	
 	public dynamic var effectivePeriod: Period?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var informationSource: Reference?
+	
 	public dynamic var medicationCodeableConcept: CodeableConcept?
+	
 	public dynamic var medicationReference: Reference?
+	
 	public dynamic var note: String?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var reasonForUseCodeableConcept: CodeableConcept?
+	
 	public dynamic var reasonForUseReference: Reference?
+	
 	public let reasonNotTaken = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var status: String?
+	
 	public let supportingInformation = RealmSwift.List<Reference>()
+	
 	public let wasNotTaken = RealmOptional<Bool>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -143,6 +159,7 @@ open class MedicationStatement: DomainResource {
 				presentKeys.insert("note")
 				if let val = exist as? String {
 					self.note = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "note", wants: String.self, has: type(of: exist)))
@@ -193,6 +210,7 @@ open class MedicationStatement: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -216,6 +234,7 @@ open class MedicationStatement: DomainResource {
 				presentKeys.insert("wasNotTaken")
 				if let val = exist as? Bool {
 					self.wasNotTaken.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "wasNotTaken", wants: Bool.self, has: type(of: exist)))
@@ -298,18 +317,31 @@ open class MedicationStatementDosage: BackboneElement {
 	}
 
 	public let asNeededBoolean = RealmOptional<Bool>()
+	
 	public dynamic var asNeededCodeableConcept: CodeableConcept?
+	
 	public dynamic var maxDosePerPeriod: Ratio?
+	
 	public dynamic var method: CodeableConcept?
+	
 	public dynamic var quantityQuantity: Quantity?
+	
 	public dynamic var quantityRange: Range?
+	
 	public dynamic var rateRange: Range?
+	
 	public dynamic var rateRatio: Ratio?
+	
 	public dynamic var route: CodeableConcept?
+	
 	public dynamic var siteCodeableConcept: CodeableConcept?
+	
 	public dynamic var siteReference: Reference?
+	
 	public dynamic var text: String?
+	
 	public dynamic var timing: Timing?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -319,6 +351,7 @@ open class MedicationStatementDosage: BackboneElement {
 				presentKeys.insert("asNeededBoolean")
 				if let val = exist as? Bool {
 					self.asNeededBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "asNeededBoolean", wants: Bool.self, has: type(of: exist)))
@@ -418,6 +451,7 @@ open class MedicationStatementDosage: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/MessageHeader.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/MessageHeader.swift
@@ -2,7 +2,7 @@
 //  MessageHeader.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MessageHeader) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MessageHeader) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,16 +23,27 @@ open class MessageHeader: DomainResource {
 	}
 
 	public dynamic var author: Reference?
+	
 	public let data = RealmSwift.List<Reference>()
+	
 	public let destination = RealmSwift.List<MessageHeaderDestination>()
+	
 	public dynamic var enterer: Reference?
+	
 	public dynamic var event: Coding?
+	
 	public dynamic var reason: CodeableConcept?
+	
 	public dynamic var receiver: Reference?
+	
 	public dynamic var response: MessageHeaderResponse?
+	
 	public dynamic var responsible: Reference?
+	
 	public dynamic var source: MessageHeaderSource?
+	
 	public dynamic var timestamp: Instant?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -215,8 +226,11 @@ open class MessageHeaderDestination: BackboneElement {
 	}
 
 	public dynamic var endpoint: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -232,6 +246,7 @@ open class MessageHeaderDestination: BackboneElement {
 				presentKeys.insert("endpoint")
 				if let val = exist as? String {
 					self.endpoint = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "endpoint", wants: String.self, has: type(of: exist)))
@@ -244,6 +259,7 @@ open class MessageHeaderDestination: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -291,8 +307,11 @@ open class MessageHeaderResponse: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var details: Reference?
+	
 	public dynamic var identifier: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -309,6 +328,7 @@ open class MessageHeaderResponse: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -330,6 +350,7 @@ open class MessageHeaderResponse: BackboneElement {
 				presentKeys.insert("identifier")
 				if let val = exist as? String {
 					self.identifier = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "identifier", wants: String.self, has: type(of: exist)))
@@ -371,10 +392,15 @@ open class MessageHeaderSource: BackboneElement {
 	}
 
 	public dynamic var contact: ContactPoint?
+	
 	public dynamic var endpoint: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var software: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -399,6 +425,7 @@ open class MessageHeaderSource: BackboneElement {
 				presentKeys.insert("endpoint")
 				if let val = exist as? String {
 					self.endpoint = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "endpoint", wants: String.self, has: type(of: exist)))
@@ -411,6 +438,7 @@ open class MessageHeaderSource: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -420,6 +448,7 @@ open class MessageHeaderSource: BackboneElement {
 				presentKeys.insert("software")
 				if let val = exist as? String {
 					self.software = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "software", wants: String.self, has: type(of: exist)))
@@ -429,6 +458,7 @@ open class MessageHeaderSource: BackboneElement {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Meta.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Meta.swift
@@ -2,7 +2,7 @@
 //  Meta.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Meta) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Meta) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,10 +22,15 @@ open class Meta: Element {
 	}
 
 	public dynamic var lastUpdated: Instant?
+	
 	public let profile = RealmSwift.List<RealmString>()
+	
 	public let security = RealmSwift.List<Coding>()
+	
 	public let tag = RealmSwift.List<Coding>()
+	
 	public dynamic var versionId: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -75,6 +80,7 @@ open class Meta: Element {
 				presentKeys.insert("versionId")
 				if let val = exist as? String {
 					self.versionId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "versionId", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Money.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Money.swift
@@ -2,7 +2,7 @@
 //  Money.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Money) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Money) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/NamingSystem.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/NamingSystem.swift
@@ -2,7 +2,7 @@
 //  NamingSystem.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NamingSystem) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NamingSystem) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,18 +22,31 @@ open class NamingSystem: DomainResource {
 	}
 
 	public let contact = RealmSwift.List<NamingSystemContact>()
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var kind: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var replacedBy: Reference?
+	
 	public dynamic var responsible: String?
+	
 	public dynamic var status: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public let uniqueId = RealmSwift.List<NamingSystemUniqueId>()
+	
 	public dynamic var usage: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -76,6 +89,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -85,6 +99,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("kind")
 				if let val = exist as? String {
 					self.kind = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "kind", wants: String.self, has: type(of: exist)))
@@ -97,6 +112,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -109,6 +125,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -127,6 +144,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("responsible")
 				if let val = exist as? String {
 					self.responsible = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "responsible", wants: String.self, has: type(of: exist)))
@@ -136,6 +154,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -171,6 +190,7 @@ open class NamingSystem: DomainResource {
 				presentKeys.insert("usage")
 				if let val = exist as? String {
 					self.usage = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "usage", wants: String.self, has: type(of: exist)))
@@ -250,7 +270,9 @@ open class NamingSystemContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -260,6 +282,7 @@ open class NamingSystemContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -306,9 +329,13 @@ open class NamingSystemUniqueId: BackboneElement {
 	}
 
 	public dynamic var period: Period?
+	
 	public let preferred = RealmOptional<Bool>()
+	
 	public dynamic var type: String?
+	
 	public dynamic var value: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -334,6 +361,7 @@ open class NamingSystemUniqueId: BackboneElement {
 				presentKeys.insert("preferred")
 				if let val = exist as? Bool {
 					self.preferred.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "preferred", wants: Bool.self, has: type(of: exist)))
@@ -343,6 +371,7 @@ open class NamingSystemUniqueId: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -355,6 +384,7 @@ open class NamingSystemUniqueId: BackboneElement {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Narrative.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Narrative.swift
@@ -2,7 +2,7 @@
 //  Narrative.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Narrative) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Narrative) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,7 +19,9 @@ open class Narrative: Element {
 	}
 
 	public dynamic var div: String?
+	
 	public dynamic var status: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -36,6 +38,7 @@ open class Narrative: Element {
 				presentKeys.insert("div")
 				if let val = exist as? String {
 					self.div = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "div", wants: String.self, has: type(of: exist)))
@@ -48,6 +51,7 @@ open class Narrative: Element {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/NutritionOrder.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/NutritionOrder.swift
@@ -2,7 +2,7 @@
 //  NutritionOrder.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NutritionOrder) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NutritionOrder) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,17 +21,29 @@ open class NutritionOrder: DomainResource {
 	}
 
 	public let allergyIntolerance = RealmSwift.List<Reference>()
+	
 	public dynamic var dateTime: DateTime?
+	
 	public dynamic var encounter: Reference?
+	
 	public dynamic var enteralFormula: NutritionOrderEnteralFormula?
+	
 	public let excludeFoodModifier = RealmSwift.List<CodeableConcept>()
+	
 	public let foodPreferenceModifier = RealmSwift.List<CodeableConcept>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var oralDiet: NutritionOrderOralDiet?
+	
 	public dynamic var orderer: Reference?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var status: String?
+	
 	public let supplement = RealmSwift.List<NutritionOrderSupplement>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -152,6 +164,7 @@ open class NutritionOrder: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -229,14 +242,23 @@ open class NutritionOrderEnteralFormula: BackboneElement {
 	}
 
 	public dynamic var additiveProductName: String?
+	
 	public dynamic var additiveType: CodeableConcept?
+	
 	public let administration = RealmSwift.List<NutritionOrderEnteralFormulaAdministration>()
+	
 	public dynamic var administrationInstruction: String?
+	
 	public dynamic var baseFormulaProductName: String?
+	
 	public dynamic var baseFormulaType: CodeableConcept?
+	
 	public dynamic var caloricDensity: Quantity?
+	
 	public dynamic var maxVolumeToDeliver: Quantity?
+	
 	public dynamic var routeofAdministration: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -246,6 +268,7 @@ open class NutritionOrderEnteralFormula: BackboneElement {
 				presentKeys.insert("additiveProductName")
 				if let val = exist as? String {
 					self.additiveProductName = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "additiveProductName", wants: String.self, has: type(of: exist)))
@@ -275,6 +298,7 @@ open class NutritionOrderEnteralFormula: BackboneElement {
 				presentKeys.insert("administrationInstruction")
 				if let val = exist as? String {
 					self.administrationInstruction = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "administrationInstruction", wants: String.self, has: type(of: exist)))
@@ -284,6 +308,7 @@ open class NutritionOrderEnteralFormula: BackboneElement {
 				presentKeys.insert("baseFormulaProductName")
 				if let val = exist as? String {
 					self.baseFormulaProductName = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "baseFormulaProductName", wants: String.self, has: type(of: exist)))
@@ -378,9 +403,13 @@ open class NutritionOrderEnteralFormulaAdministration: BackboneElement {
 	}
 
 	public dynamic var quantity: Quantity?
+	
 	public dynamic var rateQuantity: Quantity?
+	
 	public dynamic var rateRatio: Ratio?
+	
 	public dynamic var schedule: Timing?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -458,11 +487,17 @@ open class NutritionOrderOralDiet: BackboneElement {
 	}
 
 	public let fluidConsistencyType = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var instruction: String?
+	
 	public let nutrient = RealmSwift.List<NutritionOrderOralDietNutrient>()
+	
 	public let schedule = RealmSwift.List<Timing>()
+	
 	public let texture = RealmSwift.List<NutritionOrderOralDietTexture>()
+	
 	public let type = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -483,6 +518,7 @@ open class NutritionOrderOralDiet: BackboneElement {
 				presentKeys.insert("instruction")
 				if let val = exist as? String {
 					self.instruction = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "instruction", wants: String.self, has: type(of: exist)))
@@ -574,7 +610,9 @@ open class NutritionOrderOralDietNutrient: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var modifier: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -629,7 +667,9 @@ open class NutritionOrderOralDietTexture: BackboneElement {
 	}
 
 	public dynamic var foodType: CodeableConcept?
+	
 	public dynamic var modifier: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -683,10 +723,15 @@ open class NutritionOrderSupplement: BackboneElement {
 	}
 
 	public dynamic var instruction: String?
+	
 	public dynamic var productName: String?
+	
 	public dynamic var quantity: Quantity?
+	
 	public let schedule = RealmSwift.List<Timing>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -696,6 +741,7 @@ open class NutritionOrderSupplement: BackboneElement {
 				presentKeys.insert("instruction")
 				if let val = exist as? String {
 					self.instruction = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "instruction", wants: String.self, has: type(of: exist)))
@@ -705,6 +751,7 @@ open class NutritionOrderSupplement: BackboneElement {
 				presentKeys.insert("productName")
 				if let val = exist as? String {
 					self.productName = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "productName", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Observation.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Observation.swift
@@ -2,7 +2,7 @@
 //  Observation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Observation) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Observation) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,35 +21,65 @@ open class Observation: DomainResource {
 	}
 
 	public dynamic var bodySite: CodeableConcept?
+	
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var comments: String?
+	
 	public let component = RealmSwift.List<ObservationComponent>()
+	
 	public dynamic var dataAbsentReason: CodeableConcept?
+	
 	public dynamic var device: Reference?
+	
 	public dynamic var effectiveDateTime: DateTime?
+	
 	public dynamic var effectivePeriod: Period?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var interpretation: CodeableConcept?
+	
 	public dynamic var issued: Instant?
+	
 	public dynamic var method: CodeableConcept?
+	
 	public let performer = RealmSwift.List<Reference>()
+	
 	public let referenceRange = RealmSwift.List<ObservationReferenceRange>()
+	
 	public let related = RealmSwift.List<ObservationRelated>()
+	
 	public dynamic var specimen: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var valueAttachment: Attachment?
+	
 	public dynamic var valueCodeableConcept: CodeableConcept?
+	
 	public dynamic var valueDateTime: DateTime?
+	
 	public dynamic var valuePeriod: Period?
+	
 	public dynamic var valueQuantity: Quantity?
+	
 	public dynamic var valueRange: Range?
+	
 	public dynamic var valueRatio: Ratio?
+	
 	public dynamic var valueSampledData: SampledData?
+	
 	public dynamic var valueString: String?
+	
 	public dynamic var valueTime: FHIRTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -96,6 +126,7 @@ open class Observation: DomainResource {
 				presentKeys.insert("comments")
 				if let val = exist as? String {
 					self.comments = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comments", wants: String.self, has: type(of: exist)))
@@ -241,6 +272,7 @@ open class Observation: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -334,6 +366,7 @@ open class Observation: DomainResource {
 				presentKeys.insert("valueString")
 				if let val = exist as? String {
 					self.valueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueString", wants: String.self, has: type(of: exist)))
@@ -464,18 +497,31 @@ open class ObservationComponent: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var dataAbsentReason: CodeableConcept?
+	
 	public let referenceRange = RealmSwift.List<ObservationReferenceRange>()
+	
 	public dynamic var valueAttachment: Attachment?
+	
 	public dynamic var valueCodeableConcept: CodeableConcept?
+	
 	public dynamic var valueDateTime: DateTime?
+	
 	public dynamic var valuePeriod: Period?
+	
 	public dynamic var valueQuantity: Quantity?
+	
 	public dynamic var valueRange: Range?
+	
 	public dynamic var valueRatio: Ratio?
+	
 	public dynamic var valueSampledData: SampledData?
+	
 	public dynamic var valueString: String?
+	
 	public dynamic var valueTime: FHIRTime?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -595,6 +641,7 @@ open class ObservationComponent: BackboneElement {
 				presentKeys.insert("valueString")
 				if let val = exist as? String {
 					self.valueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueString", wants: String.self, has: type(of: exist)))
@@ -672,10 +719,15 @@ open class ObservationReferenceRange: BackboneElement {
 	}
 
 	public dynamic var age: Range?
+	
 	public dynamic var high: Quantity?
+	
 	public dynamic var low: Quantity?
+	
 	public dynamic var meaning: CodeableConcept?
+	
 	public dynamic var text: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -721,6 +773,7 @@ open class ObservationReferenceRange: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -766,7 +819,9 @@ open class ObservationRelated: BackboneElement {
 	}
 
 	public dynamic var target: Reference?
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -794,6 +849,7 @@ open class ObservationRelated: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/OperationDefinition.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/OperationDefinition.swift
@@ -2,7 +2,7 @@
 //  OperationDefinition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationDefinition) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationDefinition) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,24 +22,43 @@ open class OperationDefinition: DomainResource {
 	}
 
 	public dynamic var base: Reference?
+	
 	public dynamic var code: String?
+	
 	public let contact = RealmSwift.List<OperationDefinitionContact>()
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public let idempotent = RealmOptional<Bool>()
+	
 	public let instance = RealmOptional<Bool>()
+	
 	public dynamic var kind: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var notes: String?
+	
 	public let parameter = RealmSwift.List<OperationDefinitionParameter>()
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var status: String?
+	
 	public let system = RealmOptional<Bool>()
+	
 	public let type = RealmSwift.List<RealmString>()
+	
 	public dynamic var url: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -69,6 +88,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -101,6 +121,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -110,6 +131,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -119,6 +141,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("idempotent")
 				if let val = exist as? Bool {
 					self.idempotent.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "idempotent", wants: Bool.self, has: type(of: exist)))
@@ -128,6 +151,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("instance")
 				if let val = exist as? Bool {
 					self.instance.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "instance", wants: Bool.self, has: type(of: exist)))
@@ -140,6 +164,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("kind")
 				if let val = exist as? String {
 					self.kind = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "kind", wants: String.self, has: type(of: exist)))
@@ -152,6 +177,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -164,6 +190,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("notes")
 				if let val = exist as? String {
 					self.notes = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "notes", wants: String.self, has: type(of: exist)))
@@ -184,6 +211,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -193,6 +221,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -202,6 +231,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -214,6 +244,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("system")
 				if let val = exist as? Bool {
 					self.system.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: Bool.self, has: type(of: exist)))
@@ -235,6 +266,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -244,6 +276,7 @@ open class OperationDefinition: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -330,7 +363,9 @@ open class OperationDefinitionContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -340,6 +375,7 @@ open class OperationDefinitionContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -386,14 +422,23 @@ open class OperationDefinitionParameter: BackboneElement {
 	}
 
 	public dynamic var binding: OperationDefinitionParameterBinding?
+	
 	public dynamic var documentation: String?
+	
 	public dynamic var max: String?
+	
 	public let min = RealmOptional<Int>()
+	
 	public dynamic var name: String?
+	
 	public let part = RealmSwift.List<OperationDefinitionParameter>()
+	
 	public dynamic var profile: Reference?
+	
 	public dynamic var type: String?
+	
 	public dynamic var use: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -421,6 +466,7 @@ open class OperationDefinitionParameter: BackboneElement {
 				presentKeys.insert("documentation")
 				if let val = exist as? String {
 					self.documentation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "documentation", wants: String.self, has: type(of: exist)))
@@ -430,6 +476,7 @@ open class OperationDefinitionParameter: BackboneElement {
 				presentKeys.insert("max")
 				if let val = exist as? String {
 					self.max = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "max", wants: String.self, has: type(of: exist)))
@@ -442,6 +489,7 @@ open class OperationDefinitionParameter: BackboneElement {
 				presentKeys.insert("min")
 				if let val = exist as? Int {
 					self.min.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "min", wants: Int.self, has: type(of: exist)))
@@ -454,6 +502,7 @@ open class OperationDefinitionParameter: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -486,6 +535,7 @@ open class OperationDefinitionParameter: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -495,6 +545,7 @@ open class OperationDefinitionParameter: BackboneElement {
 				presentKeys.insert("use")
 				if let val = exist as? String {
 					self.use = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "use", wants: String.self, has: type(of: exist)))
@@ -554,8 +605,11 @@ open class OperationDefinitionParameterBinding: BackboneElement {
 	}
 
 	public dynamic var strength: String?
+	
 	public dynamic var valueSetReference: Reference?
+	
 	public dynamic var valueSetUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -573,6 +627,7 @@ open class OperationDefinitionParameterBinding: BackboneElement {
 				presentKeys.insert("strength")
 				if let val = exist as? String {
 					self.strength = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "strength", wants: String.self, has: type(of: exist)))
@@ -594,6 +649,7 @@ open class OperationDefinitionParameterBinding: BackboneElement {
 				presentKeys.insert("valueSetUri")
 				if let val = exist as? String {
 					self.valueSetUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueSetUri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/OperationOutcome.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/OperationOutcome.swift
@@ -2,7 +2,7 @@
 //  OperationOutcome.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationOutcome) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationOutcome) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,6 +21,7 @@ open class OperationOutcome: DomainResource {
 	}
 
 	public let issue = RealmSwift.List<OperationOutcomeIssue>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -73,10 +74,15 @@ open class OperationOutcomeIssue: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var details: CodeableConcept?
+	
 	public dynamic var diagnostics: String?
+	
 	public let location = RealmSwift.List<RealmString>()
+	
 	public dynamic var severity: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -93,6 +99,7 @@ open class OperationOutcomeIssue: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -114,6 +121,7 @@ open class OperationOutcomeIssue: BackboneElement {
 				presentKeys.insert("diagnostics")
 				if let val = exist as? String {
 					self.diagnostics = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "diagnostics", wants: String.self, has: type(of: exist)))
@@ -132,6 +140,7 @@ open class OperationOutcomeIssue: BackboneElement {
 				presentKeys.insert("severity")
 				if let val = exist as? String {
 					self.severity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "severity", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Order.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Order.swift
@@ -2,7 +2,7 @@
 //  Order.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Order) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Order) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,14 +19,23 @@ open class Order: DomainResource {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public let detail = RealmSwift.List<Reference>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var reasonCodeableConcept: CodeableConcept?
+	
 	public dynamic var reasonReference: Reference?
+	
 	public dynamic var source: Reference?
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var target: Reference?
+	
 	public dynamic var when: OrderWhen?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -175,7 +184,9 @@ open class OrderWhen: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var schedule: Timing?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/OrderResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/OrderResponse.swift
@@ -2,7 +2,7 @@
 //  OrderResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OrderResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OrderResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,12 +19,19 @@ open class OrderResponse: DomainResource {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let fulfillment = RealmSwift.List<Reference>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var orderStatus: String?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var who: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -50,6 +57,7 @@ open class OrderResponse: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -81,6 +89,7 @@ open class OrderResponse: DomainResource {
 				presentKeys.insert("orderStatus")
 				if let val = exist as? String {
 					self.orderStatus = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "orderStatus", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Organization.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Organization.swift
@@ -2,7 +2,7 @@
 //  Organization.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Organization) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Organization) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,13 +23,21 @@ open class Organization: DomainResource {
 	}
 
 	public let active = RealmOptional<Bool>()
+	
 	public let address = RealmSwift.List<Address>()
+	
 	public let contact = RealmSwift.List<OrganizationContact>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var partOf: Reference?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -39,6 +47,7 @@ open class Organization: DomainResource {
 				presentKeys.insert("active")
 				if let val = exist as? Bool {
 					self.active.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "active", wants: Bool.self, has: type(of: exist)))
@@ -81,6 +90,7 @@ open class Organization: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -161,9 +171,13 @@ open class OrganizationContact: BackboneElement {
 	}
 
 	public dynamic var address: Address?
+	
 	public dynamic var name: HumanName?
+	
 	public dynamic var purpose: CodeableConcept?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Parameters.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Parameters.swift
@@ -2,7 +2,7 @@
 //  Parameters.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Parameters) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Parameters) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,6 +22,7 @@ open class Parameters: Resource {
 	}
 
 	public let parameter = RealmSwift.List<ParametersParameter>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -65,41 +66,77 @@ open class ParametersParameter: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let part = RealmSwift.List<ParametersParameter>()
+	
 	public dynamic var resource: Resource?
+	
 	public dynamic var valueAddress: Address?
+	
 	public dynamic var valueAnnotation: Annotation?
+	
 	public dynamic var valueAttachment: Attachment?
+	
 	public dynamic var valueBase64Binary: Base64Binary?
+	
 	public let valueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var valueCode: String?
+	
 	public dynamic var valueCodeableConcept: CodeableConcept?
+	
 	public dynamic var valueCoding: Coding?
+	
 	public dynamic var valueContactPoint: ContactPoint?
+	
 	public dynamic var valueDate: FHIRDate?
+	
 	public dynamic var valueDateTime: DateTime?
+	
 	public dynamic var valueDecimal: RealmDecimal?
+	
 	public dynamic var valueHumanName: HumanName?
+	
 	public dynamic var valueId: String?
+	
 	public dynamic var valueIdentifier: Identifier?
+	
 	public dynamic var valueInstant: Instant?
+	
 	public let valueInteger = RealmOptional<Int>()
+	
 	public dynamic var valueMarkdown: String?
+	
 	public dynamic var valueMeta: Meta?
+	
 	public dynamic var valueOid: String?
+	
 	public dynamic var valuePeriod: Period?
+	
 	public let valuePositiveInt = RealmOptional<Int>()
+	
 	public dynamic var valueQuantity: Quantity?
+	
 	public dynamic var valueRange: Range?
+	
 	public dynamic var valueRatio: Ratio?
+	
 	public dynamic var valueReference: Reference?
+	
 	public dynamic var valueSampledData: SampledData?
+	
 	public dynamic var valueSignature: Signature?
+	
 	public dynamic var valueString: String?
+	
 	public dynamic var valueTime: FHIRTime?
+	
 	public dynamic var valueTiming: Timing?
+	
 	public let valueUnsignedInt = RealmOptional<Int>()
+	
 	public dynamic var valueUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -115,6 +152,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -183,6 +221,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueBoolean")
 				if let val = exist as? Bool {
 					self.valueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -192,6 +231,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueCode")
 				if let val = exist as? String {
 					self.valueCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueCode", wants: String.self, has: type(of: exist)))
@@ -264,6 +304,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueId")
 				if let val = exist as? String {
 					self.valueId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueId", wants: String.self, has: type(of: exist)))
@@ -291,6 +332,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueInteger")
 				if let val = exist as? Int {
 					self.valueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueInteger", wants: Int.self, has: type(of: exist)))
@@ -300,6 +342,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueMarkdown")
 				if let val = exist as? String {
 					self.valueMarkdown = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueMarkdown", wants: String.self, has: type(of: exist)))
@@ -318,6 +361,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueOid")
 				if let val = exist as? String {
 					self.valueOid = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueOid", wants: String.self, has: type(of: exist)))
@@ -336,6 +380,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valuePositiveInt")
 				if let val = exist as? Int {
 					self.valuePositiveInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valuePositiveInt", wants: Int.self, has: type(of: exist)))
@@ -399,6 +444,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueString")
 				if let val = exist as? String {
 					self.valueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueString", wants: String.self, has: type(of: exist)))
@@ -426,6 +472,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueUnsignedInt")
 				if let val = exist as? Int {
 					self.valueUnsignedInt.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueUnsignedInt", wants: Int.self, has: type(of: exist)))
@@ -435,6 +482,7 @@ open class ParametersParameter: BackboneElement {
 				presentKeys.insert("valueUri")
 				if let val = exist as? String {
 					self.valueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueUri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Patient.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Patient.swift
@@ -2,7 +2,7 @@
 //  Patient.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Patient) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Patient) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,24 +22,43 @@ open class Patient: DomainResource {
 	}
 
 	public let active = RealmOptional<Bool>()
+	
 	public let address = RealmSwift.List<Address>()
+	
 	public dynamic var animal: PatientAnimal?
+	
 	public dynamic var birthDate: FHIRDate?
+	
 	public let careProvider = RealmSwift.List<Reference>()
+	
 	public let communication = RealmSwift.List<PatientCommunication>()
+	
 	public let contact = RealmSwift.List<PatientContact>()
+	
 	public let deceasedBoolean = RealmOptional<Bool>()
+	
 	public dynamic var deceasedDateTime: DateTime?
+	
 	public dynamic var gender: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let link = RealmSwift.List<PatientLink>()
+	
 	public dynamic var managingOrganization: Reference?
+	
 	public dynamic var maritalStatus: CodeableConcept?
+	
 	public let multipleBirthBoolean = RealmOptional<Bool>()
+	
 	public let multipleBirthInteger = RealmOptional<Int>()
+	
 	public let name = RealmSwift.List<HumanName>()
+	
 	public let photo = RealmSwift.List<Attachment>()
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -49,6 +68,7 @@ open class Patient: DomainResource {
 				presentKeys.insert("active")
 				if let val = exist as? Bool {
 					self.active.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "active", wants: Bool.self, has: type(of: exist)))
@@ -120,6 +140,7 @@ open class Patient: DomainResource {
 				presentKeys.insert("deceasedBoolean")
 				if let val = exist as? Bool {
 					self.deceasedBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "deceasedBoolean", wants: Bool.self, has: type(of: exist)))
@@ -138,6 +159,7 @@ open class Patient: DomainResource {
 				presentKeys.insert("gender")
 				if let val = exist as? String {
 					self.gender = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "gender", wants: String.self, has: type(of: exist)))
@@ -187,6 +209,7 @@ open class Patient: DomainResource {
 				presentKeys.insert("multipleBirthBoolean")
 				if let val = exist as? Bool {
 					self.multipleBirthBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "multipleBirthBoolean", wants: Bool.self, has: type(of: exist)))
@@ -196,6 +219,7 @@ open class Patient: DomainResource {
 				presentKeys.insert("multipleBirthInteger")
 				if let val = exist as? Int {
 					self.multipleBirthInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "multipleBirthInteger", wants: Int.self, has: type(of: exist)))
@@ -315,8 +339,11 @@ open class PatientAnimal: BackboneElement {
 	}
 
 	public dynamic var breed: CodeableConcept?
+	
 	public dynamic var genderStatus: CodeableConcept?
+	
 	public dynamic var species: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -391,7 +418,9 @@ open class PatientCommunication: BackboneElement {
 	}
 
 	public dynamic var language: CodeableConcept?
+	
 	public let preferred = RealmOptional<Bool>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -419,6 +448,7 @@ open class PatientCommunication: BackboneElement {
 				presentKeys.insert("preferred")
 				if let val = exist as? Bool {
 					self.preferred.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "preferred", wants: Bool.self, has: type(of: exist)))
@@ -452,12 +482,19 @@ open class PatientContact: BackboneElement {
 	}
 
 	public dynamic var address: Address?
+	
 	public dynamic var gender: String?
+	
 	public dynamic var name: HumanName?
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var period: Period?
+	
 	public let relationship = RealmSwift.List<CodeableConcept>()
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -476,6 +513,7 @@ open class PatientContact: BackboneElement {
 				presentKeys.insert("gender")
 				if let val = exist as? String {
 					self.gender = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "gender", wants: String.self, has: type(of: exist)))
@@ -575,7 +613,9 @@ open class PatientLink: BackboneElement {
 	}
 
 	public dynamic var other: Reference?
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -604,6 +644,7 @@ open class PatientLink: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/PaymentNotice.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/PaymentNotice.swift
@@ -2,7 +2,7 @@
 //  PaymentNotice.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentNotice) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentNotice) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,15 +22,25 @@ open class PaymentNotice: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var paymentStatus: Coding?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var response: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/PaymentReconciliation.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/PaymentReconciliation.swift
@@ -2,7 +2,7 @@
 //  PaymentReconciliation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentReconciliation) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentReconciliation) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,20 +21,35 @@ open class PaymentReconciliation: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public let detail = RealmSwift.List<PaymentReconciliationDetail>()
+	
 	public dynamic var disposition: String?
+	
 	public dynamic var form: Coding?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let note = RealmSwift.List<PaymentReconciliationNote>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var outcome: String?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var requestOrganization: Reference?
+	
 	public dynamic var requestProvider: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var total: Quantity?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -70,6 +85,7 @@ open class PaymentReconciliation: DomainResource {
 				presentKeys.insert("disposition")
 				if let val = exist as? String {
 					self.disposition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "disposition", wants: String.self, has: type(of: exist)))
@@ -128,6 +144,7 @@ open class PaymentReconciliation: DomainResource {
 				presentKeys.insert("outcome")
 				if let val = exist as? String {
 					self.outcome = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "outcome", wants: String.self, has: type(of: exist)))
@@ -259,12 +276,19 @@ open class PaymentReconciliationDetail: BackboneElement {
 	}
 
 	public dynamic var amount: Quantity?
+	
 	public dynamic var date: FHIRDate?
+	
 	public dynamic var payee: Reference?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var responce: Reference?
+	
 	public dynamic var submitter: Reference?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -387,7 +411,9 @@ open class PaymentReconciliationNote: BackboneElement {
 	}
 
 	public dynamic var text: String?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -397,6 +423,7 @@ open class PaymentReconciliationNote: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Period.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Period.swift
@@ -2,7 +2,7 @@
 //  Period.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Period) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Period) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,7 +21,9 @@ open class Period: Element {
 	}
 
 	public dynamic var end: DateTime?
+	
 	public dynamic var start: DateTime?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Person.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Person.swift
@@ -2,7 +2,7 @@
 //  Person.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Person) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Person) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class Person: DomainResource {
 	}
 
 	public let active = RealmOptional<Bool>()
+	
 	public let address = RealmSwift.List<Address>()
+	
 	public dynamic var birthDate: FHIRDate?
+	
 	public dynamic var gender: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let link = RealmSwift.List<PersonLink>()
+	
 	public dynamic var managingOrganization: Reference?
+	
 	public let name = RealmSwift.List<HumanName>()
+	
 	public dynamic var photo: Attachment?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -39,6 +49,7 @@ open class Person: DomainResource {
 				presentKeys.insert("active")
 				if let val = exist as? Bool {
 					self.active.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "active", wants: Bool.self, has: type(of: exist)))
@@ -68,6 +79,7 @@ open class Person: DomainResource {
 				presentKeys.insert("gender")
 				if let val = exist as? String {
 					self.gender = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "gender", wants: String.self, has: type(of: exist)))
@@ -187,7 +199,9 @@ open class PersonLink: BackboneElement {
 	}
 
 	public dynamic var assurance: String?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -203,6 +217,7 @@ open class PersonLink: BackboneElement {
 				presentKeys.insert("assurance")
 				if let val = exist as? String {
 					self.assurance = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "assurance", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Practitioner.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Practitioner.swift
@@ -2,7 +2,7 @@
 //  Practitioner.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Practitioner) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Practitioner) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,16 +21,27 @@ open class Practitioner: DomainResource {
 	}
 
 	public let active = RealmOptional<Bool>()
+	
 	public let address = RealmSwift.List<Address>()
+	
 	public dynamic var birthDate: FHIRDate?
+	
 	public let communication = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var gender: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var name: HumanName?
+	
 	public let photo = RealmSwift.List<Attachment>()
+	
 	public let practitionerRole = RealmSwift.List<PractitionerPractitionerRole>()
+	
 	public let qualification = RealmSwift.List<PractitionerQualification>()
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -40,6 +51,7 @@ open class Practitioner: DomainResource {
 				presentKeys.insert("active")
 				if let val = exist as? Bool {
 					self.active.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "active", wants: Bool.self, has: type(of: exist)))
@@ -80,6 +92,7 @@ open class Practitioner: DomainResource {
 				presentKeys.insert("gender")
 				if let val = exist as? String {
 					self.gender = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "gender", wants: String.self, has: type(of: exist)))
@@ -206,11 +219,17 @@ open class PractitionerPractitionerRole: BackboneElement {
 	}
 
 	public let healthcareService = RealmSwift.List<Reference>()
+	
 	public let location = RealmSwift.List<Reference>()
+	
 	public dynamic var managingOrganization: Reference?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var role: CodeableConcept?
+	
 	public let specialty = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -316,9 +335,13 @@ open class PractitionerQualification: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var issuer: Reference?
+	
 	public dynamic var period: Period?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Procedure.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Procedure.swift
@@ -2,7 +2,7 @@
 //  Procedure.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Procedure) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Procedure) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,28 +22,51 @@ open class Procedure: DomainResource {
 	}
 
 	public let bodySite = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var category: CodeableConcept?
+	
 	public dynamic var code: CodeableConcept?
+	
 	public let complication = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var encounter: Reference?
+	
 	public let focalDevice = RealmSwift.List<ProcedureFocalDevice>()
+	
 	public let followUp = RealmSwift.List<CodeableConcept>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var location: Reference?
+	
 	public let notPerformed = RealmOptional<Bool>()
+	
 	public let notes = RealmSwift.List<Annotation>()
+	
 	public dynamic var outcome: CodeableConcept?
+	
 	public dynamic var performedDateTime: DateTime?
+	
 	public dynamic var performedPeriod: Period?
+	
 	public let performer = RealmSwift.List<ProcedurePerformer>()
+	
 	public dynamic var reasonCodeableConcept: CodeableConcept?
+	
 	public let reasonNotPerformed = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var reasonReference: Reference?
+	
 	public let report = RealmSwift.List<Reference>()
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public let used = RealmSwift.List<Reference>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -155,6 +178,7 @@ open class Procedure: DomainResource {
 				presentKeys.insert("notPerformed")
 				if let val = exist as? Bool {
 					self.notPerformed.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "notPerformed", wants: Bool.self, has: type(of: exist)))
@@ -262,6 +286,7 @@ open class Procedure: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -387,7 +412,9 @@ open class ProcedureFocalDevice: BackboneElement {
 	}
 
 	public dynamic var action: CodeableConcept?
+	
 	public dynamic var manipulated: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -450,7 +477,9 @@ open class ProcedurePerformer: BackboneElement {
 	}
 
 	public dynamic var actor: Reference?
+	
 	public dynamic var role: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ProcedureRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ProcedureRequest.swift
@@ -2,7 +2,7 @@
 //  ProcedureRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcedureRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcedureRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,23 +21,41 @@ open class ProcedureRequest: DomainResource {
 	}
 
 	public let asNeededBoolean = RealmOptional<Bool>()
+	
 	public dynamic var asNeededCodeableConcept: CodeableConcept?
+	
 	public let bodySite = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let notes = RealmSwift.List<Annotation>()
+	
 	public dynamic var orderedOn: DateTime?
+	
 	public dynamic var orderer: Reference?
+	
 	public dynamic var performer: Reference?
+	
 	public dynamic var priority: String?
+	
 	public dynamic var reasonCodeableConcept: CodeableConcept?
+	
 	public dynamic var reasonReference: Reference?
+	
 	public dynamic var scheduledDateTime: DateTime?
+	
 	public dynamic var scheduledPeriod: Period?
+	
 	public dynamic var scheduledTiming: Timing?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -54,6 +72,7 @@ open class ProcedureRequest: DomainResource {
 				presentKeys.insert("asNeededBoolean")
 				if let val = exist as? Bool {
 					self.asNeededBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "asNeededBoolean", wants: Bool.self, has: type(of: exist)))
@@ -153,6 +172,7 @@ open class ProcedureRequest: DomainResource {
 				presentKeys.insert("priority")
 				if let val = exist as? String {
 					self.priority = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "priority", wants: String.self, has: type(of: exist)))
@@ -207,6 +227,7 @@ open class ProcedureRequest: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ProcessRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ProcessRequest.swift
@@ -2,7 +2,7 @@
 //  ProcessRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,21 +22,37 @@ open class ProcessRequest: DomainResource {
 	}
 
 	public dynamic var action: String?
+	
 	public dynamic var created: DateTime?
+	
 	public let exclude = RealmSwift.List<RealmString>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let include = RealmSwift.List<RealmString>()
+	
 	public let item = RealmSwift.List<ProcessRequestItem>()
+	
 	public let nullify = RealmOptional<Bool>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var period: Period?
+	
 	public dynamic var provider: Reference?
+	
 	public dynamic var reference: String?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var response: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 	public dynamic var target: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -52,6 +68,7 @@ open class ProcessRequest: DomainResource {
 				presentKeys.insert("action")
 				if let val = exist as? String {
 					self.action = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "action", wants: String.self, has: type(of: exist)))
@@ -113,6 +130,7 @@ open class ProcessRequest: DomainResource {
 				presentKeys.insert("nullify")
 				if let val = exist as? Bool {
 					self.nullify.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "nullify", wants: Bool.self, has: type(of: exist)))
@@ -158,6 +176,7 @@ open class ProcessRequest: DomainResource {
 				presentKeys.insert("reference")
 				if let val = exist as? String {
 					self.reference = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reference", wants: String.self, has: type(of: exist)))
@@ -271,6 +290,7 @@ open class ProcessRequestItem: BackboneElement {
 	}
 
 	public let sequenceLinkId = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -286,6 +306,7 @@ open class ProcessRequestItem: BackboneElement {
 				presentKeys.insert("sequenceLinkId")
 				if let val = exist as? Int {
 					self.sequenceLinkId.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sequenceLinkId", wants: Int.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ProcessResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ProcessResponse.swift
@@ -2,7 +2,7 @@
 //  ProcessResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,18 +21,31 @@ open class ProcessResponse: DomainResource {
 	}
 
 	public dynamic var created: DateTime?
+	
 	public dynamic var disposition: String?
+	
 	public let error = RealmSwift.List<Coding>()
+	
 	public dynamic var form: Coding?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let notes = RealmSwift.List<ProcessResponseNotes>()
+	
 	public dynamic var organization: Reference?
+	
 	public dynamic var originalRuleset: Coding?
+	
 	public dynamic var outcome: Coding?
+	
 	public dynamic var request: Reference?
+	
 	public dynamic var requestOrganization: Reference?
+	
 	public dynamic var requestProvider: Reference?
+	
 	public dynamic var ruleset: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -51,6 +64,7 @@ open class ProcessResponse: DomainResource {
 				presentKeys.insert("disposition")
 				if let val = exist as? String {
 					self.disposition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "disposition", wants: String.self, has: type(of: exist)))
@@ -224,7 +238,9 @@ open class ProcessResponseNotes: BackboneElement {
 	}
 
 	public dynamic var text: String?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -234,6 +250,7 @@ open class ProcessResponseNotes: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Provenance.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Provenance.swift
@@ -2,7 +2,7 @@
 //  Provenance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Provenance) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Provenance) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -27,15 +27,25 @@ open class Provenance: DomainResource {
 	}
 
 	public dynamic var activity: CodeableConcept?
+	
 	public let agent = RealmSwift.List<ProvenanceAgent>()
+	
 	public let entity = RealmSwift.List<ProvenanceEntity>()
+	
 	public dynamic var location: Reference?
+	
 	public dynamic var period: Period?
+	
 	public let policy = RealmSwift.List<RealmString>()
+	
 	public let reason = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var recorded: Instant?
+	
 	public let signature = RealmSwift.List<Signature>()
+	
 	public let target = RealmSwift.List<Reference>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -210,9 +220,13 @@ open class ProvenanceAgent: BackboneElement {
 	}
 
 	public dynamic var actor: Reference?
+	
 	public let relatedAgent = RealmSwift.List<ProvenanceAgentRelatedAgent>()
+	
 	public dynamic var role: Coding?
+	
 	public dynamic var userId: Identifier?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -303,7 +317,9 @@ open class ProvenanceAgentRelatedAgent: BackboneElement {
 	}
 
 	public dynamic var target: String?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -320,6 +336,7 @@ open class ProvenanceAgentRelatedAgent: BackboneElement {
 				presentKeys.insert("target")
 				if let val = exist as? String {
 					self.target = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "target", wants: String.self, has: type(of: exist)))
@@ -368,10 +385,15 @@ open class ProvenanceEntity: BackboneElement {
 	}
 
 	public dynamic var agent: ProvenanceAgent?
+	
 	public dynamic var display: String?
+	
 	public dynamic var reference: String?
+	
 	public dynamic var role: String?
+	
 	public dynamic var type: Coding?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -398,6 +420,7 @@ open class ProvenanceEntity: BackboneElement {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -407,6 +430,7 @@ open class ProvenanceEntity: BackboneElement {
 				presentKeys.insert("reference")
 				if let val = exist as? String {
 					self.reference = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reference", wants: String.self, has: type(of: exist)))
@@ -419,6 +443,7 @@ open class ProvenanceEntity: BackboneElement {
 				presentKeys.insert("role")
 				if let val = exist as? String {
 					self.role = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "role", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Quantity.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Quantity.swift
@@ -2,7 +2,7 @@
 //  Quantity.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Quantity) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Quantity) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,10 +22,15 @@ open class Quantity: Element {
 	}
 
 	public dynamic var code: String?
+	
 	public dynamic var comparator: String?
+	
 	public dynamic var system: String?
+	
 	public dynamic var unit: String?
+	
 	public dynamic var value: RealmDecimal?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -35,6 +40,7 @@ open class Quantity: Element {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -44,6 +50,7 @@ open class Quantity: Element {
 				presentKeys.insert("comparator")
 				if let val = exist as? String {
 					self.comparator = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comparator", wants: String.self, has: type(of: exist)))
@@ -53,6 +60,7 @@ open class Quantity: Element {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -62,6 +70,7 @@ open class Quantity: Element {
 				presentKeys.insert("unit")
 				if let val = exist as? String {
 					self.unit = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "unit", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Questionnaire.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Questionnaire.swift
@@ -2,7 +2,7 @@
 //  Questionnaire.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Questionnaire) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Questionnaire) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,13 +22,21 @@ open class Questionnaire: DomainResource {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public dynamic var group: QuestionnaireGroup?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var status: String?
+	
 	public let subjectType = RealmSwift.List<RealmString>()
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -77,6 +85,7 @@ open class Questionnaire: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -86,6 +95,7 @@ open class Questionnaire: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -118,6 +128,7 @@ open class Questionnaire: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -171,13 +182,21 @@ open class QuestionnaireGroup: BackboneElement {
 	}
 
 	public let concept = RealmSwift.List<Coding>()
+	
 	public let group = RealmSwift.List<QuestionnaireGroup>()
+	
 	public dynamic var linkId: String?
+	
 	public let question = RealmSwift.List<QuestionnaireGroupQuestion>()
+	
 	public let repeats = RealmOptional<Bool>()
+	
 	public let required = RealmOptional<Bool>()
+	
 	public dynamic var text: String?
+	
 	public dynamic var title: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -209,6 +228,7 @@ open class QuestionnaireGroup: BackboneElement {
 				presentKeys.insert("linkId")
 				if let val = exist as? String {
 					self.linkId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "linkId", wants: String.self, has: type(of: exist)))
@@ -229,6 +249,7 @@ open class QuestionnaireGroup: BackboneElement {
 				presentKeys.insert("repeats")
 				if let val = exist as? Bool {
 					self.repeats.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "repeats", wants: Bool.self, has: type(of: exist)))
@@ -238,6 +259,7 @@ open class QuestionnaireGroup: BackboneElement {
 				presentKeys.insert("required")
 				if let val = exist as? Bool {
 					self.required.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "required", wants: Bool.self, has: type(of: exist)))
@@ -247,6 +269,7 @@ open class QuestionnaireGroup: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -256,6 +279,7 @@ open class QuestionnaireGroup: BackboneElement {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))
@@ -309,14 +333,23 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 	}
 
 	public let concept = RealmSwift.List<Coding>()
+	
 	public let group = RealmSwift.List<QuestionnaireGroup>()
+	
 	public dynamic var linkId: String?
+	
 	public let option = RealmSwift.List<Coding>()
+	
 	public dynamic var options: Reference?
+	
 	public let repeats = RealmOptional<Bool>()
+	
 	public let required = RealmOptional<Bool>()
+	
 	public dynamic var text: String?
+	
 	public dynamic var type: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -348,6 +381,7 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 				presentKeys.insert("linkId")
 				if let val = exist as? String {
 					self.linkId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "linkId", wants: String.self, has: type(of: exist)))
@@ -377,6 +411,7 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 				presentKeys.insert("repeats")
 				if let val = exist as? Bool {
 					self.repeats.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "repeats", wants: Bool.self, has: type(of: exist)))
@@ -386,6 +421,7 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 				presentKeys.insert("required")
 				if let val = exist as? Bool {
 					self.required.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "required", wants: Bool.self, has: type(of: exist)))
@@ -395,6 +431,7 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -404,6 +441,7 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/QuestionnaireResponse.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/QuestionnaireResponse.swift
@@ -2,7 +2,7 @@
 //  QuestionnaireResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,14 +22,23 @@ open class QuestionnaireResponse: DomainResource {
 	}
 
 	public dynamic var author: Reference?
+	
 	public dynamic var authored: DateTime?
+	
 	public dynamic var encounter: Reference?
+	
 	public dynamic var group: QuestionnaireResponseGroup?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var questionnaire: Reference?
+	
 	public dynamic var source: Reference?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -108,6 +117,7 @@ open class QuestionnaireResponse: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -176,11 +186,17 @@ open class QuestionnaireResponseGroup: BackboneElement {
 	}
 
 	public let group = RealmSwift.List<QuestionnaireResponseGroup>()
+	
 	public dynamic var linkId: String?
+	
 	public let question = RealmSwift.List<QuestionnaireResponseGroupQuestion>()
+	
 	public dynamic var subject: Reference?
+	
 	public dynamic var text: String?
+	
 	public dynamic var title: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -201,6 +217,7 @@ open class QuestionnaireResponseGroup: BackboneElement {
 				presentKeys.insert("linkId")
 				if let val = exist as? String {
 					self.linkId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "linkId", wants: String.self, has: type(of: exist)))
@@ -230,6 +247,7 @@ open class QuestionnaireResponseGroup: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -239,6 +257,7 @@ open class QuestionnaireResponseGroup: BackboneElement {
 				presentKeys.insert("title")
 				if let val = exist as? String {
 					self.title = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "title", wants: String.self, has: type(of: exist)))
@@ -286,8 +305,11 @@ open class QuestionnaireResponseGroupQuestion: BackboneElement {
 	}
 
 	public let answer = RealmSwift.List<QuestionnaireResponseGroupQuestionAnswer>()
+	
 	public dynamic var linkId: String?
+	
 	public dynamic var text: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -308,6 +330,7 @@ open class QuestionnaireResponseGroupQuestion: BackboneElement {
 				presentKeys.insert("linkId")
 				if let val = exist as? String {
 					self.linkId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "linkId", wants: String.self, has: type(of: exist)))
@@ -317,6 +340,7 @@ open class QuestionnaireResponseGroupQuestion: BackboneElement {
 				presentKeys.insert("text")
 				if let val = exist as? String {
 					self.text = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "text", wants: String.self, has: type(of: exist)))
@@ -355,19 +379,33 @@ open class QuestionnaireResponseGroupQuestionAnswer: BackboneElement {
 	}
 
 	public let group = RealmSwift.List<QuestionnaireResponseGroup>()
+	
 	public dynamic var valueAttachment: Attachment?
+	
 	public let valueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var valueCoding: Coding?
+	
 	public dynamic var valueDate: FHIRDate?
+	
 	public dynamic var valueDateTime: DateTime?
+	
 	public dynamic var valueDecimal: RealmDecimal?
+	
 	public dynamic var valueInstant: Instant?
+	
 	public let valueInteger = RealmOptional<Int>()
+	
 	public dynamic var valueQuantity: Quantity?
+	
 	public dynamic var valueReference: Reference?
+	
 	public dynamic var valueString: String?
+	
 	public dynamic var valueTime: FHIRTime?
+	
 	public dynamic var valueUri: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -397,6 +435,7 @@ open class QuestionnaireResponseGroupQuestionAnswer: BackboneElement {
 				presentKeys.insert("valueBoolean")
 				if let val = exist as? Bool {
 					self.valueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -451,6 +490,7 @@ open class QuestionnaireResponseGroupQuestionAnswer: BackboneElement {
 				presentKeys.insert("valueInteger")
 				if let val = exist as? Int {
 					self.valueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueInteger", wants: Int.self, has: type(of: exist)))
@@ -478,6 +518,7 @@ open class QuestionnaireResponseGroupQuestionAnswer: BackboneElement {
 				presentKeys.insert("valueString")
 				if let val = exist as? String {
 					self.valueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueString", wants: String.self, has: type(of: exist)))
@@ -496,6 +537,7 @@ open class QuestionnaireResponseGroupQuestionAnswer: BackboneElement {
 				presentKeys.insert("valueUri")
 				if let val = exist as? String {
 					self.valueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueUri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Range.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Range.swift
@@ -2,7 +2,7 @@
 //  Range.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Range) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Range) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,7 +21,9 @@ open class Range: Element {
 	}
 
 	public dynamic var high: Quantity?
+	
 	public dynamic var low: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Ratio.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Ratio.swift
@@ -2,7 +2,7 @@
 //  Ratio.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Ratio) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Ratio) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,7 +21,9 @@ open class Ratio: Element {
 	}
 
 	public dynamic var denominator: Quantity?
+	
 	public dynamic var numerator: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Reference.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Reference.swift
@@ -2,7 +2,7 @@
 //  Reference.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Reference) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Reference) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,7 +19,9 @@ open class Reference: Element {
 	}
 
 	public dynamic var display: String?
+	
 	public dynamic var reference: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -29,6 +31,7 @@ open class Reference: Element {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -38,6 +41,7 @@ open class Reference: Element {
 				presentKeys.insert("reference")
 				if let val = exist as? String {
 					self.reference = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reference", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ReferralRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ReferralRequest.swift
@@ -2,7 +2,7 @@
 //  ReferralRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ReferralRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ReferralRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,21 +22,37 @@ open class ReferralRequest: DomainResource {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public dynamic var dateSent: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var encounter: Reference?
+	
 	public dynamic var fulfillmentTime: Period?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var priority: CodeableConcept?
+	
 	public dynamic var reason: CodeableConcept?
+	
 	public let recipient = RealmSwift.List<Reference>()
+	
 	public dynamic var requester: Reference?
+	
 	public let serviceRequested = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var specialty: CodeableConcept?
+	
 	public dynamic var status: String?
+	
 	public let supportingInformation = RealmSwift.List<Reference>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -70,6 +86,7 @@ open class ReferralRequest: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -175,6 +192,7 @@ open class ReferralRequest: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/RelatedPerson.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/RelatedPerson.swift
@@ -2,7 +2,7 @@
 //  RelatedPerson.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RelatedPerson) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RelatedPerson) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,15 +22,25 @@ open class RelatedPerson: DomainResource {
 	}
 
 	public let address = RealmSwift.List<Address>()
+	
 	public dynamic var birthDate: FHIRDate?
+	
 	public dynamic var gender: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var name: HumanName?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var period: Period?
+	
 	public let photo = RealmSwift.List<Attachment>()
+	
 	public dynamic var relationship: CodeableConcept?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -66,6 +76,7 @@ open class RelatedPerson: DomainResource {
 				presentKeys.insert("gender")
 				if let val = exist as? String {
 					self.gender = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "gender", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Resource.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Resource.swift
@@ -2,7 +2,7 @@
 //  Resource.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Resource) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Resource) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -20,13 +20,17 @@ open class Resource: FHIRAbstractResource {
 		get { return "Resource" }
 	}
 
-	public dynamic var id = UUID().uuidString
+	public dynamic var id: String?
+	public dynamic var pk = UUID().uuidString
 	override open static func primaryKey() -> String? {
-		return "id"
+		return "pk"
 	}
 	public dynamic var implicitRules: String?
+	
 	public dynamic var language: String?
+	
 	public dynamic var meta: Meta?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -36,6 +40,7 @@ open class Resource: FHIRAbstractResource {
 				presentKeys.insert("id")
 				if let val = exist as? String {
 					self.id = val
+					self.pk = val
 				}
 				else {
 					errors.append(FHIRJSONError(key: "id", wants: String.self, has: type(of: exist)))
@@ -45,6 +50,7 @@ open class Resource: FHIRAbstractResource {
 				presentKeys.insert("implicitRules")
 				if let val = exist as? String {
 					self.implicitRules = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "implicitRules", wants: String.self, has: type(of: exist)))
@@ -54,6 +60,7 @@ open class Resource: FHIRAbstractResource {
 				presentKeys.insert("language")
 				if let val = exist as? String {
 					self.language = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "language", wants: String.self, has: type(of: exist)))
@@ -75,7 +82,9 @@ open class Resource: FHIRAbstractResource {
 	override open func asJSON() -> FHIRJSON {
 		var json = super.asJSON()
 		
+		if let id = self.id {
 			json["id"] = id.asJSON()
+		}
 		if let implicitRules = self.implicitRules {
 			json["implicitRules"] = implicitRules.asJSON()
 		}

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/RiskAssessment.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/RiskAssessment.swift
@@ -2,7 +2,7 @@
 //  RiskAssessment.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RiskAssessment) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RiskAssessment) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class RiskAssessment: DomainResource {
 	}
 
 	public let basis = RealmSwift.List<Reference>()
+	
 	public dynamic var condition: Reference?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var encounter: Reference?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var method: CodeableConcept?
+	
 	public dynamic var mitigation: String?
+	
 	public dynamic var performer: Reference?
+	
 	public let prediction = RealmSwift.List<RiskAssessmentPrediction>()
+	
 	public dynamic var subject: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -95,6 +105,7 @@ open class RiskAssessment: DomainResource {
 				presentKeys.insert("mitigation")
 				if let val = exist as? String {
 					self.mitigation = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "mitigation", wants: String.self, has: type(of: exist)))
@@ -183,13 +194,21 @@ open class RiskAssessmentPrediction: BackboneElement {
 	}
 
 	public dynamic var outcome: CodeableConcept?
+	
 	public dynamic var probabilityCodeableConcept: CodeableConcept?
+	
 	public dynamic var probabilityDecimal: RealmDecimal?
+	
 	public dynamic var probabilityRange: Range?
+	
 	public dynamic var rationale: String?
+	
 	public dynamic var relativeRisk: RealmDecimal?
+	
 	public dynamic var whenPeriod: Period?
+	
 	public dynamic var whenRange: Range?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -244,6 +263,7 @@ open class RiskAssessmentPrediction: BackboneElement {
 				presentKeys.insert("rationale")
 				if let val = exist as? String {
 					self.rationale = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "rationale", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/SampledData.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/SampledData.swift
@@ -2,7 +2,7 @@
 //  SampledData.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SampledData) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SampledData) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,12 +22,19 @@ open class SampledData: Element {
 	}
 
 	public dynamic var data: String?
+	
 	public let dimensions = RealmOptional<Int>()
+	
 	public dynamic var factor: RealmDecimal?
+	
 	public dynamic var lowerLimit: RealmDecimal?
+	
 	public dynamic var origin: Quantity?
+	
 	public dynamic var period: RealmDecimal?
+	
 	public dynamic var upperLimit: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -46,6 +53,7 @@ open class SampledData: Element {
 				presentKeys.insert("data")
 				if let val = exist as? String {
 					self.data = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "data", wants: String.self, has: type(of: exist)))
@@ -58,6 +66,7 @@ open class SampledData: Element {
 				presentKeys.insert("dimensions")
 				if let val = exist as? Int {
 					self.dimensions.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "dimensions", wants: Int.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Schedule.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Schedule.swift
@@ -2,7 +2,7 @@
 //  Schedule.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Schedule) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Schedule) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,10 +19,15 @@ open class Schedule: DomainResource {
 	}
 
 	public dynamic var actor: Reference?
+	
 	public dynamic var comment: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var planningHorizon: Period?
+	
 	public let type = RealmSwift.List<CodeableConcept>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -50,6 +55,7 @@ open class Schedule: DomainResource {
 				presentKeys.insert("comment")
 				if let val = exist as? String {
 					self.comment = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comment", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/SearchParameter.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/SearchParameter.swift
@@ -2,7 +2,7 @@
 //  SearchParameter.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SearchParameter) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SearchParameter) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,20 +21,35 @@ open class SearchParameter: DomainResource {
 	}
 
 	public dynamic var base: String?
+	
 	public dynamic var code: String?
+	
 	public let contact = RealmSwift.List<SearchParameterContact>()
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var status: String?
+	
 	public let target = RealmSwift.List<RealmString>()
+	
 	public dynamic var type: String?
+	
 	public dynamic var url: String?
+	
 	public dynamic var xpath: String?
+	
 	public dynamic var xpathUsage: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -55,6 +70,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("base")
 				if let val = exist as? String {
 					self.base = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "base", wants: String.self, has: type(of: exist)))
@@ -67,6 +83,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -99,6 +116,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -111,6 +129,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -120,6 +139,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -132,6 +152,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -141,6 +162,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -150,6 +172,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -168,6 +191,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))
@@ -180,6 +204,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -192,6 +217,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("xpath")
 				if let val = exist as? String {
 					self.xpath = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "xpath", wants: String.self, has: type(of: exist)))
@@ -201,6 +227,7 @@ open class SearchParameter: DomainResource {
 				presentKeys.insert("xpathUsage")
 				if let val = exist as? String {
 					self.xpathUsage = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "xpathUsage", wants: String.self, has: type(of: exist)))
@@ -275,7 +302,9 @@ open class SearchParameterContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -285,6 +314,7 @@ open class SearchParameterContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Signature.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Signature.swift
@@ -2,7 +2,7 @@
 //  Signature.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Signature) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Signature) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,11 +23,17 @@ open class Signature: Element {
 	}
 
 	public dynamic var blob: Base64Binary?
+	
 	public dynamic var contentType: String?
+	
 	public let type = RealmSwift.List<Coding>()
+	
 	public dynamic var when: Instant?
+	
 	public dynamic var whoReference: Reference?
+	
 	public dynamic var whoUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -60,6 +66,7 @@ open class Signature: Element {
 				presentKeys.insert("contentType")
 				if let val = exist as? String {
 					self.contentType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentType", wants: String.self, has: type(of: exist)))
@@ -107,6 +114,7 @@ open class Signature: Element {
 				presentKeys.insert("whoUri")
 				if let val = exist as? String {
 					self.whoUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "whoUri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Slot.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Slot.swift
@@ -2,7 +2,7 @@
 //  Slot.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Slot) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Slot) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,13 +19,21 @@ open class Slot: DomainResource {
 	}
 
 	public dynamic var comment: String?
+	
 	public dynamic var end: Instant?
+	
 	public dynamic var freeBusyType: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let overbooked = RealmOptional<Bool>()
+	
 	public dynamic var schedule: Reference?
+	
 	public dynamic var start: Instant?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -44,6 +52,7 @@ open class Slot: DomainResource {
 				presentKeys.insert("comment")
 				if let val = exist as? String {
 					self.comment = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comment", wants: String.self, has: type(of: exist)))
@@ -65,6 +74,7 @@ open class Slot: DomainResource {
 				presentKeys.insert("freeBusyType")
 				if let val = exist as? String {
 					self.freeBusyType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "freeBusyType", wants: String.self, has: type(of: exist)))
@@ -88,6 +98,7 @@ open class Slot: DomainResource {
 				presentKeys.insert("overbooked")
 				if let val = exist as? Bool {
 					self.overbooked.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "overbooked", wants: Bool.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Specimen.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Specimen.swift
@@ -2,7 +2,7 @@
 //  Specimen.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Specimen) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Specimen) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,15 +21,25 @@ open class Specimen: DomainResource {
 	}
 
 	public dynamic var accessionIdentifier: Identifier?
+	
 	public dynamic var collection: SpecimenCollection?
+	
 	public let container = RealmSwift.List<SpecimenContainer>()
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let parent = RealmSwift.List<Reference>()
+	
 	public dynamic var receivedTime: DateTime?
+	
 	public dynamic var status: String?
+	
 	public dynamic var subject: Reference?
+	
 	public let treatment = RealmSwift.List<SpecimenTreatment>()
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -105,6 +115,7 @@ open class Specimen: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -196,12 +207,19 @@ open class SpecimenCollection: BackboneElement {
 	}
 
 	public dynamic var bodySite: CodeableConcept?
+	
 	public dynamic var collectedDateTime: DateTime?
+	
 	public dynamic var collectedPeriod: Period?
+	
 	public dynamic var collector: Reference?
+	
 	public let comment = RealmSwift.List<RealmString>()
+	
 	public dynamic var method: CodeableConcept?
+	
 	public dynamic var quantity: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -316,12 +334,19 @@ open class SpecimenContainer: BackboneElement {
 	}
 
 	public dynamic var additiveCodeableConcept: CodeableConcept?
+	
 	public dynamic var additiveReference: Reference?
+	
 	public dynamic var capacity: Quantity?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var specimenQuantity: Quantity?
+	
 	public dynamic var type: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -358,6 +383,7 @@ open class SpecimenContainer: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -437,8 +463,11 @@ open class SpecimenTreatment: BackboneElement {
 	}
 
 	public let additive = RealmSwift.List<Reference>()
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var procedure: CodeableConcept?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -459,6 +488,7 @@ open class SpecimenTreatment: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/StructureDefinition.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/StructureDefinition.swift
@@ -2,7 +2,7 @@
 //  StructureDefinition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/StructureDefinition) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/StructureDefinition) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,30 +22,55 @@ open class StructureDefinition: DomainResource {
 	}
 
 	public let abstract = RealmOptional<Bool>()
+	
 	public dynamic var base: String?
+	
 	public let code = RealmSwift.List<Coding>()
+	
 	public dynamic var constrainedType: String?
+	
 	public let contact = RealmSwift.List<StructureDefinitionContact>()
+	
 	public let context = RealmSwift.List<RealmString>()
+	
 	public dynamic var contextType: String?
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var differential: StructureDefinitionDifferential?
+	
 	public dynamic var display: String?
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public dynamic var fhirVersion: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var kind: String?
+	
 	public let mapping = RealmSwift.List<StructureDefinitionMapping>()
+	
 	public dynamic var name: String?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var snapshot: StructureDefinitionSnapshot?
+	
 	public dynamic var status: String?
+	
 	public dynamic var url: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -65,6 +90,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("abstract")
 				if let val = exist as? Bool {
 					self.abstract.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "abstract", wants: Bool.self, has: type(of: exist)))
@@ -77,6 +103,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("base")
 				if let val = exist as? String {
 					self.base = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "base", wants: String.self, has: type(of: exist)))
@@ -97,6 +124,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("constrainedType")
 				if let val = exist as? String {
 					self.constrainedType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "constrainedType", wants: String.self, has: type(of: exist)))
@@ -126,6 +154,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("contextType")
 				if let val = exist as? String {
 					self.contextType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contextType", wants: String.self, has: type(of: exist)))
@@ -135,6 +164,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -153,6 +183,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -171,6 +202,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -180,6 +212,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -189,6 +222,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("fhirVersion")
 				if let val = exist as? String {
 					self.fhirVersion = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "fhirVersion", wants: String.self, has: type(of: exist)))
@@ -209,6 +243,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("kind")
 				if let val = exist as? String {
 					self.kind = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "kind", wants: String.self, has: type(of: exist)))
@@ -232,6 +267,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -244,6 +280,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -253,6 +290,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -271,6 +309,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -283,6 +322,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -306,6 +346,7 @@ open class StructureDefinition: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -410,7 +451,9 @@ open class StructureDefinitionContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -420,6 +463,7 @@ open class StructureDefinitionContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -467,6 +511,7 @@ open class StructureDefinitionDifferential: BackboneElement {
 	}
 
 	public let element = RealmSwift.List<ElementDefinition>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -519,9 +564,13 @@ open class StructureDefinitionMapping: BackboneElement {
 	}
 
 	public dynamic var comments: String?
+	
 	public dynamic var identity: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var uri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -537,6 +586,7 @@ open class StructureDefinitionMapping: BackboneElement {
 				presentKeys.insert("comments")
 				if let val = exist as? String {
 					self.comments = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "comments", wants: String.self, has: type(of: exist)))
@@ -546,6 +596,7 @@ open class StructureDefinitionMapping: BackboneElement {
 				presentKeys.insert("identity")
 				if let val = exist as? String {
 					self.identity = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "identity", wants: String.self, has: type(of: exist)))
@@ -558,6 +609,7 @@ open class StructureDefinitionMapping: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -567,6 +619,7 @@ open class StructureDefinitionMapping: BackboneElement {
 				presentKeys.insert("uri")
 				if let val = exist as? String {
 					self.uri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "uri", wants: String.self, has: type(of: exist)))
@@ -609,6 +662,7 @@ open class StructureDefinitionSnapshot: BackboneElement {
 	}
 
 	public let element = RealmSwift.List<ElementDefinition>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Subscription.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Subscription.swift
@@ -2,7 +2,7 @@
 //  Subscription.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Subscription) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Subscription) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -24,13 +24,21 @@ open class Subscription: DomainResource {
 	}
 
 	public dynamic var channel: SubscriptionChannel?
+	
 	public let contact = RealmSwift.List<ContactPoint>()
+	
 	public dynamic var criteria: String?
+	
 	public dynamic var end: Instant?
+	
 	public dynamic var error: String?
+	
 	public dynamic var reason: String?
+	
 	public dynamic var status: String?
+	
 	public let tag = RealmSwift.List<Coding>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -72,6 +80,7 @@ open class Subscription: DomainResource {
 				presentKeys.insert("criteria")
 				if let val = exist as? String {
 					self.criteria = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "criteria", wants: String.self, has: type(of: exist)))
@@ -93,6 +102,7 @@ open class Subscription: DomainResource {
 				presentKeys.insert("error")
 				if let val = exist as? String {
 					self.error = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "error", wants: String.self, has: type(of: exist)))
@@ -102,6 +112,7 @@ open class Subscription: DomainResource {
 				presentKeys.insert("reason")
 				if let val = exist as? String {
 					self.reason = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "reason", wants: String.self, has: type(of: exist)))
@@ -114,6 +125,7 @@ open class Subscription: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -181,9 +193,13 @@ open class SubscriptionChannel: BackboneElement {
 	}
 
 	public dynamic var endpoint: String?
+	
 	public dynamic var header: String?
+	
 	public dynamic var payload: String?
+	
 	public dynamic var type: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -200,6 +216,7 @@ open class SubscriptionChannel: BackboneElement {
 				presentKeys.insert("endpoint")
 				if let val = exist as? String {
 					self.endpoint = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "endpoint", wants: String.self, has: type(of: exist)))
@@ -209,6 +226,7 @@ open class SubscriptionChannel: BackboneElement {
 				presentKeys.insert("header")
 				if let val = exist as? String {
 					self.header = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "header", wants: String.self, has: type(of: exist)))
@@ -218,6 +236,7 @@ open class SubscriptionChannel: BackboneElement {
 				presentKeys.insert("payload")
 				if let val = exist as? String {
 					self.payload = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "payload", wants: String.self, has: type(of: exist)))
@@ -230,6 +249,7 @@ open class SubscriptionChannel: BackboneElement {
 				presentKeys.insert("type")
 				if let val = exist as? String {
 					self.type = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "type", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Substance.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Substance.swift
@@ -2,7 +2,7 @@
 //  Substance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Substance) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Substance) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -19,11 +19,17 @@ open class Substance: DomainResource {
 	}
 
 	public let category = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var description_fhir: String?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public let ingredient = RealmSwift.List<SubstanceIngredient>()
+	
 	public let instance = RealmSwift.List<SubstanceInstance>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -62,6 +68,7 @@ open class Substance: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -142,7 +149,9 @@ open class SubstanceIngredient: BackboneElement {
 	}
 
 	public dynamic var quantity: Ratio?
+	
 	public dynamic var substance: Reference?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -206,8 +215,11 @@ open class SubstanceInstance: BackboneElement {
 	}
 
 	public dynamic var expiry: DateTime?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var quantity: Quantity?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/SupplyDelivery.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/SupplyDelivery.swift
@@ -2,7 +2,7 @@
 //  SupplyDelivery.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyDelivery) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyDelivery) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,16 +21,27 @@ open class SupplyDelivery: DomainResource {
 	}
 
 	public dynamic var destination: Reference?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var quantity: Quantity?
+	
 	public let receiver = RealmSwift.List<Reference>()
+	
 	public dynamic var status: String?
+	
 	public dynamic var suppliedItem: Reference?
+	
 	public dynamic var supplier: Reference?
+	
 	public dynamic var time: DateTime?
+	
 	public dynamic var type: CodeableConcept?
+	
 	public dynamic var whenPrepared: Period?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -87,6 +98,7 @@ open class SupplyDelivery: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/SupplyRequest.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/SupplyRequest.swift
@@ -2,7 +2,7 @@
 //  SupplyRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyRequest) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyRequest) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,16 +21,27 @@ open class SupplyRequest: DomainResource {
 	}
 
 	public dynamic var date: DateTime?
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var kind: CodeableConcept?
+	
 	public dynamic var orderedItem: Reference?
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var reasonCodeableConcept: CodeableConcept?
+	
 	public dynamic var reasonReference: Reference?
+	
 	public dynamic var source: Reference?
+	
 	public dynamic var status: String?
+	
 	public let supplier = RealmSwift.List<Reference>()
+	
 	public dynamic var when: SupplyRequestWhen?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -112,6 +123,7 @@ open class SupplyRequest: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -192,7 +204,9 @@ open class SupplyRequestWhen: BackboneElement {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public dynamic var schedule: Timing?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/TestScript.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/TestScript.swift
@@ -2,7 +2,7 @@
 //  TestScript.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/TestScript) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/TestScript) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -22,26 +22,47 @@ open class TestScript: DomainResource {
 	}
 
 	public let contact = RealmSwift.List<TestScriptContact>()
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public let fixture = RealmSwift.List<TestScriptFixture>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public dynamic var metadata: TestScriptMetadata?
+	
 	public let multiserver = RealmOptional<Bool>()
+	
 	public dynamic var name: String?
+	
 	public let profile = RealmSwift.List<Reference>()
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var setup: TestScriptSetup?
+	
 	public dynamic var status: String?
+	
 	public dynamic var teardown: TestScriptTeardown?
+	
 	public let test = RealmSwift.List<TestScriptTest>()
+	
 	public dynamic var url: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 	public let variable = RealmSwift.List<TestScriptVariable>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -70,6 +91,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -88,6 +110,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -97,6 +120,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -135,6 +159,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("multiserver")
 				if let val = exist as? Bool {
 					self.multiserver.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "multiserver", wants: Bool.self, has: type(of: exist)))
@@ -144,6 +169,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -167,6 +193,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -176,6 +203,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -194,6 +222,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -226,6 +255,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -260,6 +290,7 @@ open class TestScript: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -352,7 +383,9 @@ open class TestScriptContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -362,6 +395,7 @@ open class TestScriptContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -408,8 +442,11 @@ open class TestScriptFixture: BackboneElement {
 	}
 
 	public let autocreate = RealmOptional<Bool>()
+	
 	public let autodelete = RealmOptional<Bool>()
+	
 	public dynamic var resource: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -419,6 +456,7 @@ open class TestScriptFixture: BackboneElement {
 				presentKeys.insert("autocreate")
 				if let val = exist as? Bool {
 					self.autocreate.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "autocreate", wants: Bool.self, has: type(of: exist)))
@@ -428,6 +466,7 @@ open class TestScriptFixture: BackboneElement {
 				presentKeys.insert("autodelete")
 				if let val = exist as? Bool {
 					self.autodelete.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "autodelete", wants: Bool.self, has: type(of: exist)))
@@ -475,7 +514,9 @@ open class TestScriptMetadata: BackboneElement {
 	}
 
 	public let capability = RealmSwift.List<TestScriptMetadataCapability>()
+	
 	public let link = RealmSwift.List<TestScriptMetadataLink>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -542,11 +583,17 @@ open class TestScriptMetadataCapability: BackboneElement {
 	}
 
 	public dynamic var conformance: Reference?
+	
 	public dynamic var description_fhir: String?
+	
 	public let destination = RealmOptional<Int>()
+	
 	public let link = RealmSwift.List<RealmString>()
+	
 	public let required = RealmOptional<Bool>()
+	
 	public let validated = RealmOptional<Bool>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -574,6 +621,7 @@ open class TestScriptMetadataCapability: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -583,6 +631,7 @@ open class TestScriptMetadataCapability: BackboneElement {
 				presentKeys.insert("destination")
 				if let val = exist as? Int {
 					self.destination.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "destination", wants: Int.self, has: type(of: exist)))
@@ -601,6 +650,7 @@ open class TestScriptMetadataCapability: BackboneElement {
 				presentKeys.insert("required")
 				if let val = exist as? Bool {
 					self.required.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "required", wants: Bool.self, has: type(of: exist)))
@@ -610,6 +660,7 @@ open class TestScriptMetadataCapability: BackboneElement {
 				presentKeys.insert("validated")
 				if let val = exist as? Bool {
 					self.validated.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "validated", wants: Bool.self, has: type(of: exist)))
@@ -657,7 +708,9 @@ open class TestScriptMetadataLink: BackboneElement {
 	}
 
 	public dynamic var description_fhir: String?
+	
 	public dynamic var url: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -673,6 +726,7 @@ open class TestScriptMetadataLink: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -682,6 +736,7 @@ open class TestScriptMetadataLink: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -718,7 +773,9 @@ open class TestScriptSetup: BackboneElement {
 	}
 
 	public let action = RealmSwift.List<TestScriptSetupAction>()
+	
 	public dynamic var metadata: TestScriptMetadata?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -783,7 +840,9 @@ open class TestScriptSetupAction: BackboneElement {
 	}
 
 	public dynamic var assert: TestScriptSetupActionAssert?
+	
 	public dynamic var operation: TestScriptSetupActionOperation?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -837,23 +896,41 @@ open class TestScriptSetupActionAssert: BackboneElement {
 	}
 
 	public dynamic var compareToSourceId: String?
+	
 	public dynamic var compareToSourcePath: String?
+	
 	public dynamic var contentType: String?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var direction: String?
+	
 	public dynamic var headerField: String?
+	
 	public dynamic var label: String?
+	
 	public dynamic var minimumId: String?
+	
 	public let navigationLinks = RealmOptional<Bool>()
+	
 	public dynamic var operator_fhir: String?
+	
 	public dynamic var path: String?
+	
 	public dynamic var resource: String?
+	
 	public dynamic var response: String?
+	
 	public dynamic var responseCode: String?
+	
 	public dynamic var sourceId: String?
+	
 	public dynamic var validateProfileId: String?
+	
 	public dynamic var value: String?
+	
 	public let warningOnly = RealmOptional<Bool>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -863,6 +940,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("compareToSourceId")
 				if let val = exist as? String {
 					self.compareToSourceId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "compareToSourceId", wants: String.self, has: type(of: exist)))
@@ -872,6 +950,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("compareToSourcePath")
 				if let val = exist as? String {
 					self.compareToSourcePath = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "compareToSourcePath", wants: String.self, has: type(of: exist)))
@@ -881,6 +960,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("contentType")
 				if let val = exist as? String {
 					self.contentType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentType", wants: String.self, has: type(of: exist)))
@@ -890,6 +970,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -899,6 +980,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("direction")
 				if let val = exist as? String {
 					self.direction = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "direction", wants: String.self, has: type(of: exist)))
@@ -908,6 +990,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("headerField")
 				if let val = exist as? String {
 					self.headerField = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "headerField", wants: String.self, has: type(of: exist)))
@@ -917,6 +1000,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("label")
 				if let val = exist as? String {
 					self.label = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "label", wants: String.self, has: type(of: exist)))
@@ -926,6 +1010,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("minimumId")
 				if let val = exist as? String {
 					self.minimumId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "minimumId", wants: String.self, has: type(of: exist)))
@@ -935,6 +1020,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("navigationLinks")
 				if let val = exist as? Bool {
 					self.navigationLinks.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "navigationLinks", wants: Bool.self, has: type(of: exist)))
@@ -944,6 +1030,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("operator")
 				if let val = exist as? String {
 					self.operator_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "operator", wants: String.self, has: type(of: exist)))
@@ -953,6 +1040,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("path")
 				if let val = exist as? String {
 					self.path = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "path", wants: String.self, has: type(of: exist)))
@@ -962,6 +1050,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("resource")
 				if let val = exist as? String {
 					self.resource = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "resource", wants: String.self, has: type(of: exist)))
@@ -971,6 +1060,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("response")
 				if let val = exist as? String {
 					self.response = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "response", wants: String.self, has: type(of: exist)))
@@ -980,6 +1070,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("responseCode")
 				if let val = exist as? String {
 					self.responseCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "responseCode", wants: String.self, has: type(of: exist)))
@@ -989,6 +1080,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("sourceId")
 				if let val = exist as? String {
 					self.sourceId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sourceId", wants: String.self, has: type(of: exist)))
@@ -998,6 +1090,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("validateProfileId")
 				if let val = exist as? String {
 					self.validateProfileId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "validateProfileId", wants: String.self, has: type(of: exist)))
@@ -1007,6 +1100,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))
@@ -1016,6 +1110,7 @@ open class TestScriptSetupActionAssert: BackboneElement {
 				presentKeys.insert("warningOnly")
 				if let val = exist as? Bool {
 					self.warningOnly.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "warningOnly", wants: Bool.self, has: type(of: exist)))
@@ -1099,19 +1194,33 @@ open class TestScriptSetupActionOperation: BackboneElement {
 	}
 
 	public dynamic var accept: String?
+	
 	public dynamic var contentType: String?
+	
 	public dynamic var description_fhir: String?
+	
 	public let destination = RealmOptional<Int>()
+	
 	public let encodeRequestUrl = RealmOptional<Bool>()
+	
 	public dynamic var label: String?
+	
 	public dynamic var params: String?
+	
 	public let requestHeader = RealmSwift.List<TestScriptSetupActionOperationRequestHeader>()
+	
 	public dynamic var resource: String?
+	
 	public dynamic var responseId: String?
+	
 	public dynamic var sourceId: String?
+	
 	public dynamic var targetId: String?
+	
 	public dynamic var type: Coding?
+	
 	public dynamic var url: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1121,6 +1230,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("accept")
 				if let val = exist as? String {
 					self.accept = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "accept", wants: String.self, has: type(of: exist)))
@@ -1130,6 +1240,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("contentType")
 				if let val = exist as? String {
 					self.contentType = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "contentType", wants: String.self, has: type(of: exist)))
@@ -1139,6 +1250,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -1148,6 +1260,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("destination")
 				if let val = exist as? Int {
 					self.destination.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "destination", wants: Int.self, has: type(of: exist)))
@@ -1157,6 +1270,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("encodeRequestUrl")
 				if let val = exist as? Bool {
 					self.encodeRequestUrl.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "encodeRequestUrl", wants: Bool.self, has: type(of: exist)))
@@ -1166,6 +1280,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("label")
 				if let val = exist as? String {
 					self.label = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "label", wants: String.self, has: type(of: exist)))
@@ -1175,6 +1290,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("params")
 				if let val = exist as? String {
 					self.params = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "params", wants: String.self, has: type(of: exist)))
@@ -1195,6 +1311,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("resource")
 				if let val = exist as? String {
 					self.resource = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "resource", wants: String.self, has: type(of: exist)))
@@ -1204,6 +1321,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("responseId")
 				if let val = exist as? String {
 					self.responseId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "responseId", wants: String.self, has: type(of: exist)))
@@ -1213,6 +1331,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("sourceId")
 				if let val = exist as? String {
 					self.sourceId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sourceId", wants: String.self, has: type(of: exist)))
@@ -1222,6 +1341,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("targetId")
 				if let val = exist as? String {
 					self.targetId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "targetId", wants: String.self, has: type(of: exist)))
@@ -1240,6 +1360,7 @@ open class TestScriptSetupActionOperation: BackboneElement {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -1311,7 +1432,9 @@ open class TestScriptSetupActionOperationRequestHeader: BackboneElement {
 	}
 
 	public dynamic var field: String?
+	
 	public dynamic var value: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1328,6 +1451,7 @@ open class TestScriptSetupActionOperationRequestHeader: BackboneElement {
 				presentKeys.insert("field")
 				if let val = exist as? String {
 					self.field = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "field", wants: String.self, has: type(of: exist)))
@@ -1340,6 +1464,7 @@ open class TestScriptSetupActionOperationRequestHeader: BackboneElement {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))
@@ -1378,6 +1503,7 @@ open class TestScriptTeardown: BackboneElement {
 	}
 
 	public let action = RealmSwift.List<TestScriptTeardownAction>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1430,6 +1556,7 @@ open class TestScriptTeardownAction: BackboneElement {
 	}
 
 	public dynamic var operation: TestScriptSetupActionOperation?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1469,9 +1596,13 @@ open class TestScriptTest: BackboneElement {
 	}
 
 	public let action = RealmSwift.List<TestScriptTestAction>()
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var metadata: TestScriptMetadata?
+	
 	public dynamic var name: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1501,6 +1632,7 @@ open class TestScriptTest: BackboneElement {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -1519,6 +1651,7 @@ open class TestScriptTest: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1560,7 +1693,9 @@ open class TestScriptTestAction: BackboneElement {
 	}
 
 	public dynamic var assert: TestScriptSetupActionAssert?
+	
 	public dynamic var operation: TestScriptSetupActionOperation?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1614,9 +1749,13 @@ open class TestScriptVariable: BackboneElement {
 	}
 
 	public dynamic var headerField: String?
+	
 	public dynamic var name: String?
+	
 	public dynamic var path: String?
+	
 	public dynamic var sourceId: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1632,6 +1771,7 @@ open class TestScriptVariable: BackboneElement {
 				presentKeys.insert("headerField")
 				if let val = exist as? String {
 					self.headerField = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "headerField", wants: String.self, has: type(of: exist)))
@@ -1641,6 +1781,7 @@ open class TestScriptVariable: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1653,6 +1794,7 @@ open class TestScriptVariable: BackboneElement {
 				presentKeys.insert("path")
 				if let val = exist as? String {
 					self.path = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "path", wants: String.self, has: type(of: exist)))
@@ -1662,6 +1804,7 @@ open class TestScriptVariable: BackboneElement {
 				presentKeys.insert("sourceId")
 				if let val = exist as? String {
 					self.sourceId = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "sourceId", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/Timing.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/Timing.swift
@@ -2,7 +2,7 @@
 //  Timing.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Timing) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Timing) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -23,8 +23,11 @@ open class Timing: Element {
 	}
 
 	public dynamic var code: CodeableConcept?
+	
 	public let event = RealmSwift.List<DateTime>()
+	
 	public dynamic var repeat_fhir: TimingRepeat?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -90,18 +93,31 @@ open class TimingRepeat: Element {
 	}
 
 	public dynamic var boundsPeriod: Period?
+	
 	public dynamic var boundsQuantity: Quantity?
+	
 	public dynamic var boundsRange: Range?
+	
 	public let count = RealmOptional<Int>()
+	
 	public dynamic var duration: RealmDecimal?
+	
 	public dynamic var durationMax: RealmDecimal?
+	
 	public dynamic var durationUnits: String?
+	
 	public let frequency = RealmOptional<Int>()
+	
 	public let frequencyMax = RealmOptional<Int>()
+	
 	public dynamic var period: RealmDecimal?
+	
 	public dynamic var periodMax: RealmDecimal?
+	
 	public dynamic var periodUnits: String?
+	
 	public dynamic var when: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -138,6 +154,7 @@ open class TimingRepeat: Element {
 				presentKeys.insert("count")
 				if let val = exist as? Int {
 					self.count.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "count", wants: Int.self, has: type(of: exist)))
@@ -165,6 +182,7 @@ open class TimingRepeat: Element {
 				presentKeys.insert("durationUnits")
 				if let val = exist as? String {
 					self.durationUnits = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "durationUnits", wants: String.self, has: type(of: exist)))
@@ -174,6 +192,7 @@ open class TimingRepeat: Element {
 				presentKeys.insert("frequency")
 				if let val = exist as? Int {
 					self.frequency.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "frequency", wants: Int.self, has: type(of: exist)))
@@ -183,6 +202,7 @@ open class TimingRepeat: Element {
 				presentKeys.insert("frequencyMax")
 				if let val = exist as? Int {
 					self.frequencyMax.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "frequencyMax", wants: Int.self, has: type(of: exist)))
@@ -210,6 +230,7 @@ open class TimingRepeat: Element {
 				presentKeys.insert("periodUnits")
 				if let val = exist as? String {
 					self.periodUnits = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "periodUnits", wants: String.self, has: type(of: exist)))
@@ -219,6 +240,7 @@ open class TimingRepeat: Element {
 				presentKeys.insert("when")
 				if let val = exist as? String {
 					self.when = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "when", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/ValueSet.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/ValueSet.swift
@@ -2,7 +2,7 @@
 //  ValueSet.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ValueSet) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ValueSet) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,24 +21,43 @@ open class ValueSet: DomainResource {
 	}
 
 	public dynamic var codeSystem: ValueSetCodeSystem?
+	
 	public dynamic var compose: ValueSetCompose?
+	
 	public let contact = RealmSwift.List<ValueSetContact>()
+	
 	public dynamic var copyright: String?
+	
 	public dynamic var date: DateTime?
+	
 	public dynamic var description_fhir: String?
+	
 	public dynamic var expansion: ValueSetExpansion?
+	
 	public let experimental = RealmOptional<Bool>()
+	
 	public let extensible = RealmOptional<Bool>()
+	
 	public dynamic var identifier: Identifier?
+	
 	public let immutable = RealmOptional<Bool>()
+	
 	public dynamic var lockedDate: FHIRDate?
+	
 	public dynamic var name: String?
+	
 	public dynamic var publisher: String?
+	
 	public dynamic var requirements: String?
+	
 	public dynamic var status: String?
+	
 	public dynamic var url: String?
+	
 	public let useContext = RealmSwift.List<CodeableConcept>()
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -83,6 +102,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("copyright")
 				if let val = exist as? String {
 					self.copyright = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "copyright", wants: String.self, has: type(of: exist)))
@@ -101,6 +121,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("description")
 				if let val = exist as? String {
 					self.description_fhir = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "description", wants: String.self, has: type(of: exist)))
@@ -119,6 +140,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("experimental")
 				if let val = exist as? Bool {
 					self.experimental.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "experimental", wants: Bool.self, has: type(of: exist)))
@@ -128,6 +150,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("extensible")
 				if let val = exist as? Bool {
 					self.extensible.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "extensible", wants: Bool.self, has: type(of: exist)))
@@ -146,6 +169,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("immutable")
 				if let val = exist as? Bool {
 					self.immutable.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "immutable", wants: Bool.self, has: type(of: exist)))
@@ -164,6 +188,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -173,6 +198,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("publisher")
 				if let val = exist as? String {
 					self.publisher = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "publisher", wants: String.self, has: type(of: exist)))
@@ -182,6 +208,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("requirements")
 				if let val = exist as? String {
 					self.requirements = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "requirements", wants: String.self, has: type(of: exist)))
@@ -191,6 +218,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("status")
 				if let val = exist as? String {
 					self.status = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "status", wants: String.self, has: type(of: exist)))
@@ -203,6 +231,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("url")
 				if let val = exist as? String {
 					self.url = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "url", wants: String.self, has: type(of: exist)))
@@ -223,6 +252,7 @@ open class ValueSet: DomainResource {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -310,9 +340,13 @@ open class ValueSetCodeSystem: BackboneElement {
 	}
 
 	public let caseSensitive = RealmOptional<Bool>()
+	
 	public let concept = RealmSwift.List<ValueSetCodeSystemConcept>()
+	
 	public dynamic var system: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -329,6 +363,7 @@ open class ValueSetCodeSystem: BackboneElement {
 				presentKeys.insert("caseSensitive")
 				if let val = exist as? Bool {
 					self.caseSensitive.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "caseSensitive", wants: Bool.self, has: type(of: exist)))
@@ -352,6 +387,7 @@ open class ValueSetCodeSystem: BackboneElement {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -364,6 +400,7 @@ open class ValueSetCodeSystem: BackboneElement {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -406,11 +443,17 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 	}
 
 	public let abstract = RealmOptional<Bool>()
+	
 	public dynamic var code: String?
+	
 	public let concept = RealmSwift.List<ValueSetCodeSystemConcept>()
+	
 	public dynamic var definition: String?
+	
 	public let designation = RealmSwift.List<ValueSetCodeSystemConceptDesignation>()
+	
 	public dynamic var display: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -426,6 +469,7 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 				presentKeys.insert("abstract")
 				if let val = exist as? Bool {
 					self.abstract.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "abstract", wants: Bool.self, has: type(of: exist)))
@@ -435,6 +479,7 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -458,6 +503,7 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 				presentKeys.insert("definition")
 				if let val = exist as? String {
 					self.definition = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "definition", wants: String.self, has: type(of: exist)))
@@ -478,6 +524,7 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -526,8 +573,11 @@ open class ValueSetCodeSystemConceptDesignation: BackboneElement {
 	}
 
 	public dynamic var language: String?
+	
 	public dynamic var use: Coding?
+	
 	public dynamic var value: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -543,6 +593,7 @@ open class ValueSetCodeSystemConceptDesignation: BackboneElement {
 				presentKeys.insert("language")
 				if let val = exist as? String {
 					self.language = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "language", wants: String.self, has: type(of: exist)))
@@ -561,6 +612,7 @@ open class ValueSetCodeSystemConceptDesignation: BackboneElement {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))
@@ -603,8 +655,11 @@ open class ValueSetCompose: BackboneElement {
 	}
 
 	public let exclude = RealmSwift.List<ValueSetComposeInclude>()
+	
 	public let import_fhir = RealmSwift.List<RealmString>()
+	
 	public let include = RealmSwift.List<ValueSetComposeInclude>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -672,9 +727,13 @@ open class ValueSetComposeInclude: BackboneElement {
 	}
 
 	public let concept = RealmSwift.List<ValueSetComposeIncludeConcept>()
+	
 	public let filter = RealmSwift.List<ValueSetComposeIncludeFilter>()
+	
 	public dynamic var system: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -712,6 +771,7 @@ open class ValueSetComposeInclude: BackboneElement {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -724,6 +784,7 @@ open class ValueSetComposeInclude: BackboneElement {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -765,8 +826,11 @@ open class ValueSetComposeIncludeConcept: BackboneElement {
 	}
 
 	public dynamic var code: String?
+	
 	public let designation = RealmSwift.List<ValueSetCodeSystemConceptDesignation>()
+	
 	public dynamic var display: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -782,6 +846,7 @@ open class ValueSetComposeIncludeConcept: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -805,6 +870,7 @@ open class ValueSetComposeIncludeConcept: BackboneElement {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -844,8 +910,11 @@ open class ValueSetComposeIncludeFilter: BackboneElement {
 	}
 
 	public dynamic var op: String?
+	
 	public dynamic var property: String?
+	
 	public dynamic var value: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -863,6 +932,7 @@ open class ValueSetComposeIncludeFilter: BackboneElement {
 				presentKeys.insert("op")
 				if let val = exist as? String {
 					self.op = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "op", wants: String.self, has: type(of: exist)))
@@ -875,6 +945,7 @@ open class ValueSetComposeIncludeFilter: BackboneElement {
 				presentKeys.insert("property")
 				if let val = exist as? String {
 					self.property = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "property", wants: String.self, has: type(of: exist)))
@@ -887,6 +958,7 @@ open class ValueSetComposeIncludeFilter: BackboneElement {
 				presentKeys.insert("value")
 				if let val = exist as? String {
 					self.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "value", wants: String.self, has: type(of: exist)))
@@ -928,7 +1000,9 @@ open class ValueSetContact: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let telecom = RealmSwift.List<ContactPoint>()
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -938,6 +1012,7 @@ open class ValueSetContact: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -985,11 +1060,17 @@ open class ValueSetExpansion: BackboneElement {
 	}
 
 	public let contains = RealmSwift.List<ValueSetExpansionContains>()
+	
 	public dynamic var identifier: String?
+	
 	public let offset = RealmOptional<Int>()
+	
 	public let parameter = RealmSwift.List<ValueSetExpansionParameter>()
+	
 	public dynamic var timestamp: DateTime?
+	
 	public let total = RealmOptional<Int>()
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1017,6 +1098,7 @@ open class ValueSetExpansion: BackboneElement {
 				presentKeys.insert("identifier")
 				if let val = exist as? String {
 					self.identifier = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "identifier", wants: String.self, has: type(of: exist)))
@@ -1029,6 +1111,7 @@ open class ValueSetExpansion: BackboneElement {
 				presentKeys.insert("offset")
 				if let val = exist as? Int {
 					self.offset.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "offset", wants: Int.self, has: type(of: exist)))
@@ -1061,6 +1144,7 @@ open class ValueSetExpansion: BackboneElement {
 				presentKeys.insert("total")
 				if let val = exist as? Int {
 					self.total.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "total", wants: Int.self, has: type(of: exist)))
@@ -1108,11 +1192,17 @@ open class ValueSetExpansionContains: BackboneElement {
 	}
 
 	public let abstract = RealmOptional<Bool>()
+	
 	public dynamic var code: String?
+	
 	public let contains = RealmSwift.List<ValueSetExpansionContains>()
+	
 	public dynamic var display: String?
+	
 	public dynamic var system: String?
+	
 	public dynamic var version: String?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -1122,6 +1212,7 @@ open class ValueSetExpansionContains: BackboneElement {
 				presentKeys.insert("abstract")
 				if let val = exist as? Bool {
 					self.abstract.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "abstract", wants: Bool.self, has: type(of: exist)))
@@ -1131,6 +1222,7 @@ open class ValueSetExpansionContains: BackboneElement {
 				presentKeys.insert("code")
 				if let val = exist as? String {
 					self.code = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "code", wants: String.self, has: type(of: exist)))
@@ -1151,6 +1243,7 @@ open class ValueSetExpansionContains: BackboneElement {
 				presentKeys.insert("display")
 				if let val = exist as? String {
 					self.display = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "display", wants: String.self, has: type(of: exist)))
@@ -1160,6 +1253,7 @@ open class ValueSetExpansionContains: BackboneElement {
 				presentKeys.insert("system")
 				if let val = exist as? String {
 					self.system = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "system", wants: String.self, has: type(of: exist)))
@@ -1169,6 +1263,7 @@ open class ValueSetExpansionContains: BackboneElement {
 				presentKeys.insert("version")
 				if let val = exist as? String {
 					self.version = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "version", wants: String.self, has: type(of: exist)))
@@ -1217,12 +1312,19 @@ open class ValueSetExpansionParameter: BackboneElement {
 	}
 
 	public dynamic var name: String?
+	
 	public let valueBoolean = RealmOptional<Bool>()
+	
 	public dynamic var valueCode: String?
+	
 	public dynamic var valueDecimal: RealmDecimal?
+	
 	public let valueInteger = RealmOptional<Int>()
+	
 	public dynamic var valueString: String?
+	
 	public dynamic var valueUri: String?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -1238,6 +1340,7 @@ open class ValueSetExpansionParameter: BackboneElement {
 				presentKeys.insert("name")
 				if let val = exist as? String {
 					self.name = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "name", wants: String.self, has: type(of: exist)))
@@ -1250,6 +1353,7 @@ open class ValueSetExpansionParameter: BackboneElement {
 				presentKeys.insert("valueBoolean")
 				if let val = exist as? Bool {
 					self.valueBoolean.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueBoolean", wants: Bool.self, has: type(of: exist)))
@@ -1259,6 +1363,7 @@ open class ValueSetExpansionParameter: BackboneElement {
 				presentKeys.insert("valueCode")
 				if let val = exist as? String {
 					self.valueCode = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueCode", wants: String.self, has: type(of: exist)))
@@ -1277,6 +1382,7 @@ open class ValueSetExpansionParameter: BackboneElement {
 				presentKeys.insert("valueInteger")
 				if let val = exist as? Int {
 					self.valueInteger.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueInteger", wants: Int.self, has: type(of: exist)))
@@ -1286,6 +1392,7 @@ open class ValueSetExpansionParameter: BackboneElement {
 				presentKeys.insert("valueString")
 				if let val = exist as? String {
 					self.valueString = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueString", wants: String.self, has: type(of: exist)))
@@ -1295,6 +1402,7 @@ open class ValueSetExpansionParameter: BackboneElement {
 				presentKeys.insert("valueUri")
 				if let val = exist as? String {
 					self.valueUri = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "valueUri", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhir/classes/models/VisionPrescription.swift
+++ b/realm-swift-fhir/realm-swift-fhir/classes/models/VisionPrescription.swift
@@ -2,7 +2,7 @@
 //  VisionPrescription.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/VisionPrescription) on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/VisionPrescription) on 2017-02-01.
 //  2017, SMART Health IT.
 //
 
@@ -21,13 +21,21 @@ open class VisionPrescription: DomainResource {
 	}
 
 	public dynamic var dateWritten: DateTime?
+	
 	public let dispense = RealmSwift.List<VisionPrescriptionDispense>()
+	
 	public dynamic var encounter: Reference?
+	
 	public let identifier = RealmSwift.List<Identifier>()
+	
 	public dynamic var patient: Reference?
+	
 	public dynamic var prescriber: Reference?
+	
 	public dynamic var reasonCodeableConcept: CodeableConcept?
+	
 	public dynamic var reasonReference: Reference?
+	
 
 	
 	override open func populate(from json: FHIRJSON?, presentKeys: inout Set<String>) -> [FHIRJSONError]? {
@@ -157,20 +165,35 @@ open class VisionPrescriptionDispense: BackboneElement {
 	}
 
 	public dynamic var add: RealmDecimal?
+	
 	public let axis = RealmOptional<Int>()
+	
 	public dynamic var backCurve: RealmDecimal?
+	
 	public dynamic var base: String?
+	
 	public dynamic var brand: String?
+	
 	public dynamic var color: String?
+	
 	public dynamic var cylinder: RealmDecimal?
+	
 	public dynamic var diameter: RealmDecimal?
+	
 	public dynamic var duration: Quantity?
+	
 	public dynamic var eye: String?
+	
 	public dynamic var notes: String?
+	
 	public dynamic var power: RealmDecimal?
+	
 	public dynamic var prism: RealmDecimal?
+	
 	public dynamic var product: Coding?
+	
 	public dynamic var sphere: RealmDecimal?
+	
 
 	
 	/** Convenience initializer, taking all required properties as arguments. */
@@ -195,6 +218,7 @@ open class VisionPrescriptionDispense: BackboneElement {
 				presentKeys.insert("axis")
 				if let val = exist as? Int {
 					self.axis.value = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "axis", wants: Int.self, has: type(of: exist)))
@@ -213,6 +237,7 @@ open class VisionPrescriptionDispense: BackboneElement {
 				presentKeys.insert("base")
 				if let val = exist as? String {
 					self.base = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "base", wants: String.self, has: type(of: exist)))
@@ -222,6 +247,7 @@ open class VisionPrescriptionDispense: BackboneElement {
 				presentKeys.insert("brand")
 				if let val = exist as? String {
 					self.brand = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "brand", wants: String.self, has: type(of: exist)))
@@ -231,6 +257,7 @@ open class VisionPrescriptionDispense: BackboneElement {
 				presentKeys.insert("color")
 				if let val = exist as? String {
 					self.color = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "color", wants: String.self, has: type(of: exist)))
@@ -267,6 +294,7 @@ open class VisionPrescriptionDispense: BackboneElement {
 				presentKeys.insert("eye")
 				if let val = exist as? String {
 					self.eye = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "eye", wants: String.self, has: type(of: exist)))
@@ -276,6 +304,7 @@ open class VisionPrescriptionDispense: BackboneElement {
 				presentKeys.insert("notes")
 				if let val = exist as? String {
 					self.notes = val
+					
 				}
 				else {
 					errors.append(FHIRJSONError(key: "notes", wants: String.self, has: type(of: exist)))

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/AccountTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/AccountTests.swift
@@ -2,7 +2,7 @@
 //  AccountTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/AllergyIntoleranceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/AllergyIntoleranceTests.swift
@@ -2,7 +2,7 @@
 //  AllergyIntoleranceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/AppointmentResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/AppointmentResponseTests.swift
@@ -2,7 +2,7 @@
 //  AppointmentResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/AppointmentTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/AppointmentTests.swift
@@ -2,7 +2,7 @@
 //  AppointmentTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/AuditEventTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/AuditEventTests.swift
@@ -2,7 +2,7 @@
 //  AuditEventTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/BasicTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/BasicTests.swift
@@ -2,7 +2,7 @@
 //  BasicTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/BinaryTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/BinaryTests.swift
@@ -2,7 +2,7 @@
 //  BinaryTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/BodySiteTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/BodySiteTests.swift
@@ -2,7 +2,7 @@
 //  BodySiteTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/BundleTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/BundleTests.swift
@@ -2,7 +2,7 @@
 //  BundleTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/CarePlanTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/CarePlanTests.swift
@@ -2,7 +2,7 @@
 //  CarePlanTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ClaimResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ClaimResponseTests.swift
@@ -2,7 +2,7 @@
 //  ClaimResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ClaimTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ClaimTests.swift
@@ -2,7 +2,7 @@
 //  ClaimTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ClinicalImpressionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ClinicalImpressionTests.swift
@@ -2,7 +2,7 @@
 //  ClinicalImpressionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/CommunicationRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/CommunicationRequestTests.swift
@@ -2,7 +2,7 @@
 //  CommunicationRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/CommunicationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/CommunicationTests.swift
@@ -2,7 +2,7 @@
 //  CommunicationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/CompositionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/CompositionTests.swift
@@ -2,7 +2,7 @@
 //  CompositionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ConceptMapTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ConceptMapTests.swift
@@ -2,7 +2,7 @@
 //  ConceptMapTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ConditionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ConditionTests.swift
@@ -2,7 +2,7 @@
 //  ConditionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ConformanceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ConformanceTests.swift
@@ -2,7 +2,7 @@
 //  ConformanceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ContractTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ContractTests.swift
@@ -2,7 +2,7 @@
 //  ContractTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/CoverageTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/CoverageTests.swift
@@ -2,7 +2,7 @@
 //  CoverageTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DataElementTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DataElementTests.swift
@@ -2,7 +2,7 @@
 //  DataElementTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DetectedIssueTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DetectedIssueTests.swift
@@ -2,7 +2,7 @@
 //  DetectedIssueTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceComponentTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceComponentTests.swift
@@ -2,7 +2,7 @@
 //  DeviceComponentTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceMetricTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceMetricTests.swift
@@ -2,7 +2,7 @@
 //  DeviceMetricTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceTests.swift
@@ -2,7 +2,7 @@
 //  DeviceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceUseRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceUseRequestTests.swift
@@ -2,7 +2,7 @@
 //  DeviceUseRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceUseStatementTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DeviceUseStatementTests.swift
@@ -2,7 +2,7 @@
 //  DeviceUseStatementTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DiagnosticOrderTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DiagnosticOrderTests.swift
@@ -2,7 +2,7 @@
 //  DiagnosticOrderTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DiagnosticReportTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DiagnosticReportTests.swift
@@ -2,7 +2,7 @@
 //  DiagnosticReportTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DocumentManifestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DocumentManifestTests.swift
@@ -2,7 +2,7 @@
 //  DocumentManifestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/DocumentReferenceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/DocumentReferenceTests.swift
@@ -2,7 +2,7 @@
 //  DocumentReferenceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/EligibilityRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/EligibilityRequestTests.swift
@@ -2,7 +2,7 @@
 //  EligibilityRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/EligibilityResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/EligibilityResponseTests.swift
@@ -2,7 +2,7 @@
 //  EligibilityResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/EncounterTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/EncounterTests.swift
@@ -2,7 +2,7 @@
 //  EncounterTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/EnrollmentRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/EnrollmentRequestTests.swift
@@ -2,7 +2,7 @@
 //  EnrollmentRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/EnrollmentResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/EnrollmentResponseTests.swift
@@ -2,7 +2,7 @@
 //  EnrollmentResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/EpisodeOfCareTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/EpisodeOfCareTests.swift
@@ -2,7 +2,7 @@
 //  EpisodeOfCareTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ExplanationOfBenefitTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ExplanationOfBenefitTests.swift
@@ -2,7 +2,7 @@
 //  ExplanationOfBenefitTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/FamilyMemberHistoryTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/FamilyMemberHistoryTests.swift
@@ -2,7 +2,7 @@
 //  FamilyMemberHistoryTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/FlagTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/FlagTests.swift
@@ -2,7 +2,7 @@
 //  FlagTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/GoalTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/GoalTests.swift
@@ -2,7 +2,7 @@
 //  GoalTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/GroupTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/GroupTests.swift
@@ -2,7 +2,7 @@
 //  GroupTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/HealthcareServiceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/HealthcareServiceTests.swift
@@ -2,7 +2,7 @@
 //  HealthcareServiceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ImagingObjectSelectionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ImagingObjectSelectionTests.swift
@@ -2,7 +2,7 @@
 //  ImagingObjectSelectionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ImagingStudyTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ImagingStudyTests.swift
@@ -2,7 +2,7 @@
 //  ImagingStudyTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ImmunizationRecommendationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ImmunizationRecommendationTests.swift
@@ -2,7 +2,7 @@
 //  ImmunizationRecommendationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ImmunizationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ImmunizationTests.swift
@@ -2,7 +2,7 @@
 //  ImmunizationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ImplementationGuideTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ImplementationGuideTests.swift
@@ -2,7 +2,7 @@
 //  ImplementationGuideTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ListTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ListTests.swift
@@ -2,7 +2,7 @@
 //  ListTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/LocationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/LocationTests.swift
@@ -2,7 +2,7 @@
 //  LocationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/MediaTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/MediaTests.swift
@@ -2,7 +2,7 @@
 //  MediaTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/MedicationOrderTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/MedicationOrderTests.swift
@@ -2,7 +2,7 @@
 //  MedicationOrderTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/MedicationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/MedicationTests.swift
@@ -2,7 +2,7 @@
 //  MedicationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/MessageHeaderTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/MessageHeaderTests.swift
@@ -2,7 +2,7 @@
 //  MessageHeaderTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/NamingSystemTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/NamingSystemTests.swift
@@ -2,7 +2,7 @@
 //  NamingSystemTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/NutritionOrderTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/NutritionOrderTests.swift
@@ -2,7 +2,7 @@
 //  NutritionOrderTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ObservationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ObservationTests.swift
@@ -2,7 +2,7 @@
 //  ObservationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/OperationDefinitionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/OperationDefinitionTests.swift
@@ -2,7 +2,7 @@
 //  OperationDefinitionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/OperationOutcomeTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/OperationOutcomeTests.swift
@@ -2,7 +2,7 @@
 //  OperationOutcomeTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/OrderResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/OrderResponseTests.swift
@@ -2,7 +2,7 @@
 //  OrderResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/OrderTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/OrderTests.swift
@@ -2,7 +2,7 @@
 //  OrderTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/OrganizationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/OrganizationTests.swift
@@ -2,7 +2,7 @@
 //  OrganizationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ParametersTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ParametersTests.swift
@@ -2,7 +2,7 @@
 //  ParametersTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/PatientTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/PatientTests.swift
@@ -2,7 +2,7 @@
 //  PatientTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/PaymentNoticeTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/PaymentNoticeTests.swift
@@ -2,7 +2,7 @@
 //  PaymentNoticeTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/PaymentReconciliationTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/PaymentReconciliationTests.swift
@@ -2,7 +2,7 @@
 //  PaymentReconciliationTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/PersonTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/PersonTests.swift
@@ -2,7 +2,7 @@
 //  PersonTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/PractitionerTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/PractitionerTests.swift
@@ -2,7 +2,7 @@
 //  PractitionerTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ProcedureRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ProcedureRequestTests.swift
@@ -2,7 +2,7 @@
 //  ProcedureRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ProcedureTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ProcedureTests.swift
@@ -2,7 +2,7 @@
 //  ProcedureTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ProcessRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ProcessRequestTests.swift
@@ -2,7 +2,7 @@
 //  ProcessRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ProcessResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ProcessResponseTests.swift
@@ -2,7 +2,7 @@
 //  ProcessResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ProvenanceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ProvenanceTests.swift
@@ -2,7 +2,7 @@
 //  ProvenanceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/QuestionnaireResponseTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/QuestionnaireResponseTests.swift
@@ -2,7 +2,7 @@
 //  QuestionnaireResponseTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/QuestionnaireTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/QuestionnaireTests.swift
@@ -2,7 +2,7 @@
 //  QuestionnaireTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ReferralRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ReferralRequestTests.swift
@@ -2,7 +2,7 @@
 //  ReferralRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/RelatedPersonTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/RelatedPersonTests.swift
@@ -2,7 +2,7 @@
 //  RelatedPersonTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/RiskAssessmentTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/RiskAssessmentTests.swift
@@ -2,7 +2,7 @@
 //  RiskAssessmentTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ScheduleTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ScheduleTests.swift
@@ -2,7 +2,7 @@
 //  ScheduleTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SearchParameterTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SearchParameterTests.swift
@@ -2,7 +2,7 @@
 //  SearchParameterTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SlotTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SlotTests.swift
@@ -2,7 +2,7 @@
 //  SlotTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SpecimenTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SpecimenTests.swift
@@ -2,7 +2,7 @@
 //  SpecimenTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/StructureDefinitionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/StructureDefinitionTests.swift
@@ -2,7 +2,7 @@
 //  StructureDefinitionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SubscriptionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SubscriptionTests.swift
@@ -2,7 +2,7 @@
 //  SubscriptionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SubstanceTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SubstanceTests.swift
@@ -2,7 +2,7 @@
 //  SubstanceTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SupplyDeliveryTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SupplyDeliveryTests.swift
@@ -2,7 +2,7 @@
 //  SupplyDeliveryTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/SupplyRequestTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/SupplyRequestTests.swift
@@ -2,7 +2,7 @@
 //  SupplyRequestTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/TestScriptTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/TestScriptTests.swift
@@ -2,7 +2,7 @@
 //  TestScriptTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/ValueSetTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/ValueSetTests.swift
@@ -2,7 +2,7 @@
 //  ValueSetTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.

--- a/realm-swift-fhir/realm-swift-fhirTests/classes/VisionPrescriptionTests.swift
+++ b/realm-swift-fhir/realm-swift-fhirTests/classes/VisionPrescriptionTests.swift
@@ -2,7 +2,7 @@
 //  VisionPrescriptionTests.swift
 //  RealmSwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-01-27.
+//  Generated from FHIR 1.0.2.7202 on 2017-02-01.
 //  2017, SMART Health IT.
 //
 // Tweaked for RealmSupport by Ryan Baldwin, University Health Network.


### PR DESCRIPTION
changed primary keys to a `pk` field instead of using the `id` field. If inflating from JSON, both `id` and `pk` will be set to the same value.