### PR TITLE
Date sortable

### DIFF
--- a/firekit/Cartfile.private
+++ b/firekit/Cartfile.private
@@ -1,3 +1,3 @@
 # Realm
-github "realm/realm-cocoa" == 2.5.0
+github "realm/realm-cocoa" == 2.7.0
 github "smart-on-fhir/fhir-parser" "70f814c"

--- a/firekit/Cartfile.resolved
+++ b/firekit/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "realm/realm-cocoa" "v2.5.0"
+github "realm/realm-cocoa" "v2.7.0"
 github "smart-on-fhir/fhir-parser" "70f814c190a06c0d37baf08a850f0399f0888bde"

--- a/firekit/fhir-parser-resources/fhir-1.6.0/DateAndTime.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/DateAndTime.swift
@@ -12,16 +12,13 @@ import RealmSwift
 /**
 A protocol for all our date and time structs.
 */
-protocol DateAndTime: CustomStringConvertible, Comparable, Equatable, RealmOptionalType {
+protocol DateAndTime: CustomStringConvertible, Comparable, Equatable {
 	
 	var nsDate: Date { get }
 }
 
-/**
-A date for use in human communication. Named `FHIRDate` to avoid the numerous collisions with `Foundation.Date`.
-
-Month and day are optional and there are no timezones.
-*/
+/// A date for use in human communication. Named `FHIRDate` to avoid the numerous collisions with `Foundation.Date`.
+/// Month and day are optional and there are no timezones.
 final public class FHIRDate: Object, DateAndTime {
 	
 	/// The year.
@@ -69,7 +66,7 @@ final public class FHIRDate: Object, DateAndTime {
 	- parameter day:   The day of the month – your responsibility to ensure the month has the desired number of days; ignored if no month is
 	                   given
 	*/
-	convenience public init(year: Int, month: Int8?, day: Int8?) {
+	convenience public init(year: Int, month: Int8? = nil, day: Int8? = nil) {
         self.init()
 		self.year = year
         self.month = month
@@ -317,11 +314,22 @@ final public class DateTime: Object, DateAndTime {
 	
 	/// The timezone
     public var timeZone: TimeZone? {
-        didSet {
-            timeZoneString = timeZone?.offset();
+        get {
+            if let identifier = timeZoneIdentifier {
+                return TimeZone(identifier: identifier)
+            }
+            
+            return nil
+        }
+        
+        set {
+            timeZoneIdentifier = newValue?.identifier
+            timeZoneString = newValue?.offset();
         }
     }
 	
+    private(set) dynamic var timeZoneIdentifier: String?
+    
     /// The timezone string seen during deserialization; to be used on serialization unless the timezone changed.
 	private(set) dynamic var timeZoneString: String?
 	
@@ -332,11 +340,22 @@ final public class DateTime: Object, DateAndTime {
 	/**
 	This very date and time.
 	
-	- returns: A DateTime instance representing current date and time.
+	- returns: A DateTime instance representing current date and time, in the current timezone.
 	*/
 	public static var now: DateTime {
-		let (date, time, tz) = DateNSDateConverter.sharedConverter.parse(date: Date())
-		return DateTime(date: date, time: time, timeZone: tz)
+        // we need to shift the date over such that when assigned the local timezone 
+        // the date/time is actually right. Without doing this then we will be off by 
+        // whatever the actual timezone offset is.
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        
+        let comp = Calendar.current.dateComponents(in: TimeZone.current, from: Date())
+        let localDate = Calendar.current.date(from: comp)!
+        return DateTime(string: formatter.string(from: localDate))!
+//		let (date, time, _) = DateNSDateConverter.sharedConverter.parse(date: localDate)
+//		return DateTime(date: date, time: time)
 	}
 	
 	/**
@@ -348,18 +367,13 @@ final public class DateTime: Object, DateAndTime {
 	- parameter time:     The time of the date-time
 	- parameter timeZone: The timezone
 	*/
-	public convenience init(date: FHIRDate, time: FHIRTime?, timeZone: TimeZone?) {
+	public convenience init(date: FHIRDate, time: FHIRTime? = nil, timeZone: TimeZone? = nil) {
         self.init()
 		self.date = date
-		self.time = time
-		if nil != time && nil == timeZone {
-			self.timeZone = TimeZone.current
-		}
-		else {
-			self.timeZone = timeZone
-		}
-
-		self.timeZoneString = self.timeZone?.offset()
+        if let time = time {
+            self.time = time
+            self.timeZone = timeZone ?? TimeZone.current
+        }
 	}
 	
 	/**
@@ -370,17 +384,14 @@ final public class DateTime: Object, DateAndTime {
 	- parameter string: The string the date-time is parsed from
 	*/
 	public convenience init?(string: String) {
-        self.init()
-		let (date, time, tz, tzString) = DateAndTimeParser.sharedParser.parse(string: string)
-		if nil == date {
-			return nil
-		}
-		self.date = date!
-		if let time = time {
-			self.time = time
-			self.timeZone = tz ?? TimeZone.current
-			self.timeZoneString = tzString
-		}
+        let (date, time, tz, tzString) = DateAndTimeParser.sharedParser.parse(string: string)
+        
+        guard let d = date else {
+            return nil
+        }
+		
+        self.init(date: d, time: time, timeZone: tz)
+        self.timeZoneString = tzString
 	}
 	
 	
@@ -802,13 +813,12 @@ extension TimeZone {
 		}
 		
 		let secsFromGMT = secondsFromGMT()
-		let hr = abs((secsFromGMT / 3600) - (secsFromGMT % 3600))
+		let hr = abs((secsFromGMT / 3600) - (((secsFromGMT % 3600) / 3600) * 60))
 		let min = abs((secsFromGMT % 3600) / 60)
 		
 		return (secsFromGMT >= 0 ? "+" : "-") + String(format: "%02d:%02d", hr, min)
 	}
 }
-
 
 /**
 Extend Scanner to account for interface differences between macOS and Linux (as of November 2016)

--- a/firekit/fhir-parser-resources/fhir-1.6.0/DateAndTimeTests.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/DateAndTimeTests.swift
@@ -550,6 +550,13 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         let nsNow = Date()
         let result = Calendar.current.compare(dtNow.nsDate, to: nsNow, toGranularity: .second)
         XCTAssertEqual(result, ComparisonResult.orderedSame)
+        
+        // make sure it's still equal after we re-inflate it from Realm
+        let realm = makeRealm()
+        try! realm.write { realm.add(dtNow) }
+        let dtNow2 = realm.objects(DateTime.self).first!
+        let result2 = Calendar.current.compare(dtNow2.nsDate, to: nsNow, toGranularity: .second)
+        XCTAssertEqual(result2, ComparisonResult.orderedSame)
     }
 }
 

--- a/firekit/fhir-parser-resources/fhir-1.6.0/DateAndTimeTests.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/DateAndTimeTests.swift
@@ -232,6 +232,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(2015, d!.date?.year)
 		XCTAssertTrue(nil == d!.date?.month)
 		XCTAssertTrue(nil == d!.time)
+        XCTAssertEqual("2015", d!.description)
 		XCTAssertTrue(nil == d!.timeZone)
 		
 		d = DateTime(string: "2015-03")
@@ -240,6 +241,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(3), d!.date?.month!)
 		XCTAssertTrue(nil == d!.date?.day)
 		XCTAssertTrue(nil == d!.time)
+        XCTAssertEqual("2015-03", d!.description)
 		XCTAssertTrue(nil == d!.timeZone)
 		
 		d = DateTime(string: "2015-03-28")
@@ -248,6 +250,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(3), d!.date?.month!)
 		XCTAssertEqual(Int8(28), d!.date?.day!)
 		XCTAssertTrue(nil == d!.time)
+        XCTAssertEqual("2015-03-28", d!.description)
 		XCTAssertTrue(nil == d!.timeZone)
 		
 		d = DateTime(string: "2015-03-28T02:33")
@@ -283,7 +286,8 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29, d!.time!.second)
-		XCTAssertFalse(nil == d!.timeZone)
+        XCTAssertEqual("2015-03-28T02:33:29+01:00", d!.description)
+        XCTAssertNotNil(d!.timeZone)
 		XCTAssertTrue(3600 == d!.timeZone!.secondsFromGMT(), "Should be 3600 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
 		d = DateTime(string: "2015-03-28T02:33:29-05:00")
@@ -295,6 +299,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29-05:00", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -307,6 +312,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-05:00", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -319,6 +325,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-05:30", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -344,6 +351,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29-05", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -356,6 +364,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-0500", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -368,6 +377,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-0530", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 	}
@@ -385,7 +395,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         
         XCTAssertEqual(inMemJSON, fetched?.asJSON())
         
-        try! realm.write { fetched?.timeZone = TimeZone(abbreviation: "EDT") }
+        try! realm.write { fetched?.timeZone = TimeZone(abbreviation: "GMT") }
         XCTAssertNotEqual(inMemJSON, fetched?.asJSON())
     }
 
@@ -504,6 +514,43 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		let ns2 = dt2.nsDate
         XCTAssertTrue(dt2 == ns2.fhir_asDateTime(), "Conversion to NSDate and back again must not alter `DateTime`")		
 	}
+    
+    func testTimezoneIsPersistedWhenDateIsSaved() {
+        let date = DateTime.now
+        
+        XCTAssertNotNil(date.time)
+        XCTAssertNotNil(date.date)
+        XCTAssertNotNil(date.nsDate)
+        XCTAssertNotNil(date.timeZoneString)
+        XCTAssertNotNil(date.timeZone)
+        
+        let realm = makeRealm()
+        
+        try! realm.write {
+            realm.add(date)
+        }
+        
+        guard let date2 = realm.objects(DateTime.self).first else {
+            XCTFail("Unable to load persisted date")
+            return
+        }
+        
+        XCTAssertNotNil(date2.time)
+        XCTAssertEqual(date.time, date2.time)
+        XCTAssertNotNil(date2.date)
+        XCTAssertNotNil(date2.nsDate)
+        XCTAssertNotNil(date2.timeZoneString)
+        XCTAssertNotNil(date2.timeZone)
+        XCTAssertEqual(date.nsDate, date2.nsDate)
+        XCTAssertEqual(date, date2)
+    }
+    
+    func testDateTimeNowIsCorrectlySetToLocalTime() {
+        let dtNow = DateTime.now
+        let nsNow = Date()
+        let result = Calendar.current.compare(dtNow.nsDate, to: nsNow, toGranularity: .second)
+        XCTAssertEqual(result, ComparisonResult.orderedSame)
+    }
 }
 
 

--- a/firekit/firekit/classes/models/DateAndTime.swift
+++ b/firekit/firekit/classes/models/DateAndTime.swift
@@ -313,16 +313,19 @@ final public class DateTime: Object, DateAndTime {
     ///             internals and you will enter a world of pain.
     ///     ```
     ///     // do this
-    ///     let now = DateTime.now
-    ///     let now.date = FHIRDate(year: 2017, month: 6, day: 15)
-    ///     print(now.nsDate)
-    ///     > 2017-06-15T17:52:17.764-04:00
-    ///
-    ///     // or this
     ///     now.date!.year = 2015
     ///     now.date = now.date!
     ///     print(now.nsDate)
     ///     > 2015-06-15T17:52:17.764-04:00
+    ///
+    ///     // or this
+    ///     let now = DateTime.now
+    ///     let newDate = FHIRDate(year: 2017, month: 6, day: 15)
+    ///     let now.date = newDate
+    ///     print(now.nsDate)
+    ///     > 2017-06-15T17:52:17.764-04:00
+    ///     // if the DateTime is already saved you'll need to delete the now.date before assigning now.date, 
+    ///     // otherwise Realm will orphan that date time.
     ///
     ///     // but don't just do this or else you will eventually cry at 2am.
     ///     // note how the `nsDate` is now out of synch, and still sitting around in 2015
@@ -338,31 +341,12 @@ final public class DateTime: Object, DateAndTime {
         }
     }
     
+    private dynamic var fhirTime: FHIRTime?
     /// The FHIRTime of this DateTime
     /// - Warning: If you wish to update a DateTime's `time` directly, it is strongly advised that you re-set
     ///             the DateTime's `time` to itself afterwards. Failing to do so will fail to synchronize the DateTime
-    ///             internals and you will enter a world of pain.
-    ///     ```
-    ///     // do this
-    ///     let now = DateTime.now
-    ///     let now.time = FHIRTime(hour: 15, minute: 7, second: 32)
-    ///     print(now.nsDate)
-    ///     > 2017-06-15T17:07:32.764-04:00
-    ///
-    ///     // or this
-    ///     now.time!.hour = 12
-    ///     now.time = now.time!
-    ///     print(now.nsDate)
-    ///     > 2017-06-15T17:07:32.764-04:00
-    ///
-    ///     // but don't just do this or else you will eventually cry at 2am.
-    ///     // note how the `nsDate` is now out of synch, and still sitting around in 12 O'clock
-    ///     now.time!.hour = 9
-    ///     print(now.nsDate)
-    ///     > 2017-06-15T12:07:32.764-04:00
-    ///     ```
-    private dynamic var fhirTime: FHIRTime?
-    /// The time.
+    ///             internals and you will enter a world of pain. This works identically to `date`.
+    ///             See `date` for further details.
     public var time: FHIRTime? {
         get { return fhirTime }
         set {

--- a/firekit/firekit/classes/models/DateAndTime.swift
+++ b/firekit/firekit/classes/models/DateAndTime.swift
@@ -306,6 +306,54 @@ final public class FHIRTime: Object, DateAndTime {
  */
 final public class DateTime: Object, DateAndTime {
     
+    /// The original date string representing this DateTime. 
+    /// Could be as simple as just a year, such as "2017", or a full ISO8601 datetime string.
+    public private(set) dynamic var dateString: String = ""
+    
+    /// The identifier for the timezone
+    public private(set) dynamic var timeZoneIdentifier: String?
+    
+    /// The timezone string seen during deserialization; to be used on serialization unless the timezone changed.
+    public private(set) dynamic var timeZoneString: String?
+    
+    /// The timezone. When set will update the `nsDate`, `timeZoneIdentifier`, and `timeZoneString` internals.
+    public var timeZone: TimeZone? {
+        get {
+            if let identifier = timeZoneIdentifier {
+                return TimeZone(identifier: identifier)
+            }
+            
+            return nil
+        }
+        
+        set {
+            timeZoneIdentifier = newValue?.identifier
+            timeZoneString = newValue?.offset();
+            updateDateIfNeeded()
+        }
+    }
+    
+    private dynamic var value: Date = Date()
+    /// The actual Date object representing this DateTime under the hood.
+    /// Since only a year is required for a DateTime, any missing value (such as month, or minute)
+    /// will default to the lowest possible value.
+    /// - Attention: When querying a DateTime via `nsDate`, use `value`. For example:
+    ///
+    /// ```
+    /// // this isn't going to return much unless you have DateTimes in the future
+    /// realm.objects(DateTime.self).filter('value > %@', Date())
+    /// ```
+    public var nsDate: Date {
+        get {
+            return value
+        }
+        
+        set {
+            value = newValue
+            dateString = makeFormatter(in: self.timeZone).string(from: value)
+        }
+    }
+    
     /// The FHIRDate of this DateTime
     /// - Warning: If you wish to update a DateTime's `date` directly, you _must_ re-set
     ///             the DateTime's `date` to itself afterwards. Failing to do so will fail to synchronize the DateTime
@@ -337,6 +385,7 @@ final public class DateTime: Object, DateAndTime {
         get {
             let (date, _, _, _) = DateAndTimeParser.sharedParser.parse(string: self.dateString)
             return date
+        }
         
         set {
             let d = makeDate(newValue, time: time, timeZone: timeZone)
@@ -345,38 +394,56 @@ final public class DateTime: Object, DateAndTime {
     }
     
     /// The FHIRTime of this DateTime
+    /// - Warning: If you wish to update a DateTime's `time` directly, you _must_ re-set
     ///             the DateTime's `time` to itself afterwards. Failing to do so will fail to synchronize the DateTime
     ///             internals and you will enter a world of pain. This works identically to `date`.
     ///             See `date` for further details.
+    /// - Attention: This property is not persisted, and is instead computed from the DateTime internals.
     public var time: FHIRTime? {
-        set {
-        }
-    }
-    
         get {
+            let (_, time, _, _) = DateAndTimeParser.sharedParser.parse(string: self.dateString)
+            return time
         }
         
         set {
+            let d = makeDate(date, time: newValue, timeZone: timeZone)
+            nsDate = d
         }
     }
     
-    
-    
+    public override class func ignoredProperties() -> [String] {
+        return ["date", "time", "timeZone", "nsDate"]
     }
     
+    /// A DateTime instance representing current date and time, in the current timezone.
     public static var now: DateTime {
         // we need to shift the date over such that when assigned the local timezone
         // the date/time is actually right. Without doing this then we will be off by
         // whatever the actual timezone offset is.
         let comp = Calendar.current.dateComponents(in: TimeZone.current, from: Date())
         let localDate = Calendar.current.date(from: comp)!
+        return DateTime(string: localFormatter.string(from: localDate))!
     }
     
+    /// Designated initializer, takes a date and optionally a time and a timezone.
+    ///
+    /// If time is given but no timezone, the instance is assigned the local time zone.
+    ///
+    /// - Parameters:
+    ///   - date: The date of the DateTime
+    ///   - time: The time of the DateTime
+    ///   - timeZone: The timezone. Will default to TimeZone.current if not provided.
+    public convenience init(date: FHIRDate, time: FHIRTime? = nil, timeZone: TimeZone?) {
         self.init()
         
+        if time != nil {
             let tz = timeZone ?? TimeZone.current
             timeZoneIdentifier = tz.identifier
+            timeZoneString = tz.offset()
         }
+
+        self.dateString = makeDescription(date: date, time: time)
+        self.value = makeDate(date, time: time, timeZone: timeZone ?? TimeZone.current)
     }
     
     /**
@@ -394,10 +461,20 @@ final public class DateTime: Object, DateAndTime {
         }
         
         self.init(date: d, time: time, timeZone: tz)
+        self.dateString = string
         self.timeZoneString = tzString
     }
     
+    private func makeDescription(date: FHIRDate?, time: FHIRTime?) -> String {
+        if let tm = time, let tz = timeZoneString ?? timeZone?.offset() {
+            return "\((date ?? FHIRDate.today).description)T\(tm.description)\(tz)"
         }
+        
+        return (date ?? FHIRDate.today).description
+    }
+    
+    public override var description: String {
+        return makeDescription(date: date, time: time)
     }
     
     public static func <(lhs: DateTime, rhs: DateTime) -> Bool {
@@ -412,13 +489,8 @@ final public class DateTime: Object, DateAndTime {
         return (lhd.compare(rhd) == .orderedSame)
     }
     
-    private func makeDate() -> Date {
-                                                              time: time, timeZone: tz)
-        }
-    }
-    
     private func updateDateIfNeeded() {
-        let d = makeDate()
+        let d = makeDate(date, time: time, timeZone: timeZone)
         if d != nsDate { nsDate = d }
     }
 }
@@ -427,61 +499,147 @@ final public class DateTime: Object, DateAndTime {
 An instant in time, known at least to the second and with a timezone, for machine times.
 */
 final public class Instant: Object, DateAndTime {
-	
-	/// The date.
-    private dynamic var _date: FHIRDate? = FHIRDate.today {
-        didSet {
-            if nil == _date?.month {
-                _date?.month = 1
-            }
-            if nil == _date?.day {
-                _date?.day = 1
-            }
-        }
-    }
+    /// The original date string representing this DateTime.
+    /// Could be as simple as just a year, such as "2017", or a full ISO8601 datetime string.
+	public private(set) dynamic var dateString = ""
     
+    /// The FHIRDate of this `Instant`
+    /// - Warning: If you wish to update a DateTime's `date` directly, you _must_ re-set
+    ///             the DateTime's `date` to itself afterwards. Failing to do so will fail to synchronize the DateTime
+    ///             internals and you will enter a world of pain.
+    ///     ```
+    ///     // do this
+    ///     now.date!.year = 2015
+    ///     now.date = now.date!
+    ///     print(now.nsDate)
+    ///     > 2015-06-15T17:52:17.764-04:00
+    ///
+    ///     // or this
+    ///     let now = DateTime.now
+    ///     let newDate = FHIRDate(year: 2017, month: 6, day: 15)
+    ///     let now.date = newDate
+    ///     print(now.nsDate)
+    ///     > 2017-06-15T17:52:17.764-04:00
+    ///     // if the DateTime is already saved you'll need to delete the now.date before assigning now.date,
+    ///     // otherwise Realm will orphan that date time.
+    ///
+    ///     // but don't just do this or else you will eventually cry at 2am.
+    ///     // note how the `nsDate` is now out of synch, and still sitting around in 2015
+    ///     now.date!.year = 2013
+    ///     print(now.nsDate)
+    ///     > 2015-06-15T17:52:17.764-04:00
+    ///     ```
+    /// - Attention: This property is not persisted, and is instead computed from the DateTime internals.
     public var date: FHIRDate {
         get {
-            return _date!
+            let (date, _, _, _) = DateAndTimeParser.sharedParser.parse(string: self.dateString)
+            return date ?? FHIRDate.today
         }
+        
         set {
-            _date = newValue
+            if nil == newValue.day {
+                newValue.day = 1
+            }
+            
+            if nil == newValue.month {
+                newValue.month = 1
+            }
+            
+            let d = makeDate(newValue, time: time, timeZone: timeZone)
+            nsDate = d
         }
-    }
-	
-	/// The time, including seconds.
-	private dynamic var _time: FHIRTime? = FHIRTime.now
-    public var time: FHIRTime {
-        get {
-            return _time!
-        }
-        set {
-            _time = newValue
-        }
-    }
-	
-	/// The timezone.
-    public var timeZone: TimeZone = TimeZone.current {
-		didSet {
-			timeZoneString = nil
-		}
-	}
-	
-    public override class func ignoredProperties() -> [String] {
-        return ["timeZone", "date", "time"]
     }
     
-	/// The timezone string seen during deserialization; to be used on serialization unless the timezone changed.
-	private dynamic var timeZoneString: String?
+    /// The FHIRTime of this `Instant`
+    /// - Warning: If you wish to update a DateTime's `time` directly, you _must_ re-set
+    ///             the DateTime's `time` to itself afterwards. Failing to do so will fail to synchronize the DateTime
+    ///             internals and you will enter a world of pain. This works identically to `date`.
+    ///             See `date` for further details.
+    /// - Attention: This property is not persisted, and is instead computed from the DateTime internals.
+    public var time: FHIRTime {
+        get {
+            let (_, time, _, _) = DateAndTimeParser.sharedParser.parse(string: self.dateString)
+            return time!
+        }
+        
+        set {
+            let d = makeDate(date, time: newValue, timeZone: timeZone)
+            nsDate = d
+        }
+    }
+    
+    /// The identifier for the timezone
+    public private(set) dynamic var timeZoneIdentifier: String = TimeZone.current.identifier
+    
+    /// The timezone string seen during deserialization; to be used on serialization unless the timezone changed.
+    public private(set) dynamic var timeZoneString: String = TimeZone.current.offset()
+    
+    /// The timezone. When set will update the `nsDate`, `timeZoneIdentifier`, and `timeZoneString` internals.
+    public var timeZone: TimeZone {
+        get {
+            return TimeZone(identifier: timeZoneIdentifier)!
+        }
+        
+        set {
+            timeZoneIdentifier = newValue.identifier
+            timeZoneString = newValue.offset();
+            updateDateIfNeeded()
+        }
+    }
+    
+    private dynamic var value: Date = Date()
+    /// The actual Date object representing this DateTime under the hood.
+    /// Since only a year is required for a DateTime, any missing value (such as month, or minute)
+    /// will default to the lowest possible value.
+    /// - Attention: When querying a DateTime via `nsDate`, use `value`. For example:
+    ///
+    /// ```
+    /// // this isn't going to return much unless you have DateTimes in the future
+    /// realm.objects(DateTime.self).filter('value > %@', Date())
+    /// ```
+    public var nsDate: Date {
+        get {
+            return value
+        }
+        
+        set {
+            value = newValue
+            dateString = Instant.makeFormatter(in: self.timeZone).string(from: value)
+        }
+    }
 	
+    public override class func ignoredProperties() -> [String] {
+        return ["date", "time", "timeZone", "nsDate"]
+    }
+    
+    private static func makeFormatter(in timeZone: TimeZone?) -> DateFormatter {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .iso8601)
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        
+        if timeZone != nil {
+            f.timeZone = timeZone
+        }
+        
+        return f
+    }
+    
+    private static var localFormatter: DateFormatter {
+        return makeFormatter(in: TimeZone.current)
+    }
+    
 	/**
 	This very instant.
 	
-	- returns: An Instant instance representing current date and time.
+	- returns: An Instant instance representing current date and time in the current timezone.
 	*/
 	public static var now: Instant {
-		let (date, time, tz) = DateNSDateConverter.sharedConverter.parse(date: Date())
-		return Instant(date: date, time: time, timeZone: tz)
+        // we need to shift the date over such that when assigned the local timezone
+        // the date/time is actually right. Without doing this then we will be off by
+        // twice as much as to whatever the actual timezone offset is.
+        let comp = Calendar.current.dateComponents(in: TimeZone.current, from: Date())
+        let localDate = Calendar.current.date(from: comp)!
+        return Instant(string: localFormatter.string(from: localDate))!
 	}
 	
 	/**
@@ -493,15 +651,16 @@ final public class Instant: Object, DateAndTime {
 	*/
 	public convenience init(date: FHIRDate, time: FHIRTime, timeZone: TimeZone) {
         self.init()
-		self.date = date
-		if nil == self.date.month {
-			self.date.month = 1
-		}
-		if nil == self.date.day {
-			self.date.day = 1
-		}
-		self.time = time
-		self.timeZone = timeZone
+        if date.month == nil { date.month = 1 }
+        if date.day == nil { date.day = 1 }
+        
+        self.value = makeDate(date, time: time, timeZone: timeZone)
+        self.timeZoneIdentifier = timeZone.identifier
+        self.timeZoneString = timeZone.offset()
+        
+        if dateString == "" {
+            self.dateString = makeDescription(date: date, time: time, timeZoneString: timeZoneString)
+        }
 	}
 	
 	/** Uses `DateAndTimeParser` to initialize from a date-time string.
@@ -510,25 +669,28 @@ final public class Instant: Object, DateAndTime {
 	*/
 	public convenience init?(string: String) {
         self.init()
-		let (date, time, tz, tzString) = DateAndTimeParser.sharedParser.parse(string: string)
-		if nil == date || nil == date!.month || nil == date!.day || nil == time || nil == tz {
-			return nil
-		}
-		self.date = date!
-		self.time = time!
-		self.timeZone = tz!
-		self.timeZoneString = tzString!
+        let (d, t, tz, tzString) = DateAndTimeParser.sharedParser.parse(string: string)
+        guard let date = d, date.month != nil, date.day != nil, let time = t, let timeZone = tz else {
+            return nil
+        }
+		
+        self.dateString = string
+        self.value = makeDate(date, time: time, timeZone: timeZone)
+        self.timeZoneIdentifier = timeZone.identifier
+        self.timeZoneString = tzString!
 	}
-	
-	// MARK: Protocols
-	
-	public var nsDate: Date {
-		return DateNSDateConverter.sharedConverter.create(date: date, time: time, timeZone: timeZone)
-	}
-	
+    
+    private func updateDateIfNeeded() {
+        let d = makeDate(date, time: time, timeZone: timeZone)
+        if d != nsDate { nsDate = d }
+    }
+    
+    private func makeDescription(date: FHIRDate, time: FHIRTime, timeZoneString: String) -> String{
+        return "\(date.description)T\(time.description)\(timeZoneString)"
+    }
+    
 	public override var description: String {
-		let tz = timeZoneString ?? timeZone.offset()
-		return "\(date.description)T\(time.description)\(tz)"
+		return makeDescription(date: date, time: time, timeZoneString: timeZoneString)
 	}
 	
 	public static func <(lhs: Instant, rhs: Instant) -> Bool {
@@ -862,4 +1024,28 @@ extension Scanner {
 		#endif
 		return flag ? int : nil
 	}
+}
+
+fileprivate func makeFormatter(in timeZone: TimeZone?) -> DateFormatter {
+    let f = DateFormatter()
+    f.calendar = Calendar(identifier: .iso8601)
+    f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+    
+    if timeZone != nil {
+        f.timeZone = timeZone
+    }
+    
+    return f
+}
+
+fileprivate var localFormatter: DateFormatter {
+    return makeFormatter(in: TimeZone.current)
+}
+
+fileprivate func makeDate(_ date: FHIRDate?, time: FHIRTime?, timeZone: TimeZone?) -> Date {
+    if let time = time, let tz = timeZone {
+        return DateNSDateConverter.sharedConverter.create(date: date ?? FHIRDate.today,
+                                                          time: time, timeZone: tz)
+    }
+    return DateNSDateConverter.sharedConverter.create(fromDate: date ?? FHIRDate.today)
 }

--- a/firekit/firekit/classes/models/DateAndTime.swift
+++ b/firekit/firekit/classes/models/DateAndTime.swift
@@ -307,8 +307,30 @@ final public class FHIRTime: Object, DateAndTime {
 final public class DateTime: Object, DateAndTime {
     
     private dynamic var fhirDate: FHIRDate?
-    /// The date.
-    public dynamic var date: FHIRDate? {
+    /// The FHIRDate of this DateTime
+    /// - Warning: If you wish to update a DateTime's `date` directly, it is strongly advised that you re-set
+    ///             the DateTime's `date` to itself afterwards. Failing to do so will fail to synchronize the DateTime
+    ///             internals and you will enter a world of pain.
+    ///     ```
+    ///     // do this
+    ///     let now = DateTime.now
+    ///     let now.date = FHIRDate(year: 2017, month: 6, day: 15)
+    ///     print(now.nsDate)
+    ///     > 2017-06-15T17:52:17.764-04:00
+    ///
+    ///     // or this
+    ///     now.date!.year = 2015
+    ///     now.date = now.date!
+    ///     print(now.nsDate)
+    ///     > 2015-06-15T17:52:17.764-04:00
+    ///
+    ///     // but don't just do this or else you will eventually cry at 2am.
+    ///     // note how the `nsDate` is now out of synch, and still sitting around in 2015
+    ///     now.date!.year = 2013
+    ///     print(now.nsDate)
+    ///     > 2015-06-15T17:52:17.764-04:00
+    ///     ```
+    public var date: FHIRDate? {
         get { return fhirDate }
         set {
             fhirDate = newValue
@@ -316,9 +338,32 @@ final public class DateTime: Object, DateAndTime {
         }
     }
     
+    /// The FHIRTime of this DateTime
+    /// - Warning: If you wish to update a DateTime's `time` directly, it is strongly advised that you re-set
+    ///             the DateTime's `time` to itself afterwards. Failing to do so will fail to synchronize the DateTime
+    ///             internals and you will enter a world of pain.
+    ///     ```
+    ///     // do this
+    ///     let now = DateTime.now
+    ///     let now.time = FHIRTime(hour: 15, minute: 7, second: 32)
+    ///     print(now.nsDate)
+    ///     > 2017-06-15T17:07:32.764-04:00
+    ///
+    ///     // or this
+    ///     now.time!.hour = 12
+    ///     now.time = now.time!
+    ///     print(now.nsDate)
+    ///     > 2017-06-15T17:07:32.764-04:00
+    ///
+    ///     // but don't just do this or else you will eventually cry at 2am.
+    ///     // note how the `nsDate` is now out of synch, and still sitting around in 12 O'clock
+    ///     now.time!.hour = 9
+    ///     print(now.nsDate)
+    ///     > 2017-06-15T12:07:32.764-04:00
+    ///     ```
     private dynamic var fhirTime: FHIRTime?
     /// The time.
-    public dynamic var time: FHIRTime? {
+    public var time: FHIRTime? {
         get { return fhirTime }
         set {
             fhirTime = newValue
@@ -326,7 +371,7 @@ final public class DateTime: Object, DateAndTime {
         }
     }
     
-    /// The timezone
+    /// The timezone. When set will update the `nsDate`, `timeZoneIdentifier`, and `timeZoneString` internals.
     public var timeZone: TimeZone? {
         get {
             if let identifier = timeZoneIdentifier {

--- a/firekit/firekit/classes/models/DateAndTime.swift
+++ b/firekit/firekit/classes/models/DateAndTime.swift
@@ -306,22 +306,22 @@ final public class FHIRTime: Object, DateAndTime {
  */
 final public class DateTime: Object, DateAndTime {
     
-    private dynamic var _date: FHIRDate?
+    private dynamic var fhirDate: FHIRDate?
     /// The date.
     public dynamic var date: FHIRDate? {
-        get { return _date }
+        get { return fhirDate }
         set {
-            _date = newValue
+            fhirDate = newValue
             updateDateIfNeeded()
         }
     }
     
-    private dynamic var _time: FHIRTime?
+    private dynamic var fhirTime: FHIRTime?
     /// The time.
     public dynamic var time: FHIRTime? {
-        get { return _time }
+        get { return fhirTime }
         set {
-            _time = newValue
+            fhirTime = newValue
             updateDateIfNeeded()
         }
     }
@@ -384,11 +384,16 @@ final public class DateTime: Object, DateAndTime {
      */
     public convenience init(date: FHIRDate, time: FHIRTime? = nil, timeZone: TimeZone? = nil) {
         self.init()
-        _date = date
+        
+        fhirDate = date
         if let time = time {
-            _time = time
-            self.timeZone = timeZone ?? TimeZone.current
+            fhirTime = time
+            
+            let tz = timeZone ?? TimeZone.current
+            timeZoneIdentifier = tz.identifier
+            timeZoneString = tz.offset();
         }
+        updateDateIfNeeded()
     }
     
     /**
@@ -431,10 +436,11 @@ final public class DateTime: Object, DateAndTime {
     }
     
     private func makeDate() -> Date {
-        if let time = time, let tz = timeZone {
-            return DateNSDateConverter.sharedConverter.create(date: date ?? FHIRDate.today, time: time, timeZone: tz)
+        if let time = fhirTime, let tz = timeZone {
+            return DateNSDateConverter.sharedConverter.create(date: fhirDate ?? FHIRDate.today,
+                                                              time: time, timeZone: tz)
         }
-        return DateNSDateConverter.sharedConverter.create(fromDate: date ?? FHIRDate.today)
+        return DateNSDateConverter.sharedConverter.create(fromDate: fhirDate ?? FHIRDate.today)
     }
     
     private func updateDateIfNeeded() {

--- a/firekit/firekit/classes/models/DateAndTime.swift
+++ b/firekit/firekit/classes/models/DateAndTime.swift
@@ -343,8 +343,19 @@ final public class DateTime: Object, DateAndTime {
 	- returns: A DateTime instance representing current date and time, in the current timezone.
 	*/
 	public static var now: DateTime {
-		let (date, time, _) = DateNSDateConverter.sharedConverter.parse(date: Date())
-		return DateTime(date: date, time: time)
+        // we need to shift the date over such that when assigned the local timezone 
+        // the date/time is actually right. Without doing this then we will be off by 
+        // whatever the actual timezone offset is.
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        
+        let comp = Calendar.current.dateComponents(in: TimeZone.current, from: Date())
+        let localDate = Calendar.current.date(from: comp)!
+        return DateTime(string: formatter.string(from: localDate))!
+//		let (date, time, _) = DateNSDateConverter.sharedConverter.parse(date: localDate)
+//		return DateTime(date: date, time: time)
 	}
 	
 	/**
@@ -807,19 +818,6 @@ extension TimeZone {
 		
 		return (secsFromGMT >= 0 ? "+" : "-") + String(format: "%02d:%02d", hr, min)
 	}
-}
-
-extension Formatter {
-    static let iso8601Extended: DateFormatter = {
-        let formatter = DateFormatter()
-        
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-        
-        return formatter
-    }()
 }
 
 /**

--- a/firekit/firekitTests/classes/BundleTests.swift
+++ b/firekit/firekitTests/classes/BundleTests.swift
@@ -18,7 +18,7 @@ class BundleTests: XCTestCase, RealmPersistenceTesting {
 	override func setUp() {
 		realm = makeRealm()
 	}
-
+    
 	func instantiateFrom(_ filename: String) throws -> FireKit.Bundle {
 		return instantiateFrom(try readJSONFile(filename))
 	}

--- a/firekit/firekitTests/classes/DateAndTimeTests.swift
+++ b/firekit/firekitTests/classes/DateAndTimeTests.swift
@@ -562,6 +562,38 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         let result2 = Calendar.current.compare(dtNow2.nsDate, to: nsNow, toGranularity: .second)
         XCTAssertEqual(result2, ComparisonResult.orderedSame)
     }
+    
+    func testUpdatingTimezoneUpdatesNsDate() {
+        let now = DateTime.now
+        
+        // shift the timezone over by an hour so that this test isn't as geographically fragile
+        let nextTimezone = TimeZone(secondsFromGMT: (now.timeZone?.secondsFromGMT() ?? 0) + 3600)
+        XCTAssertNotNil(nextTimezone)
+        let originalNsDate = now.nsDate
+        now.timeZone = nextTimezone
+        XCTAssertNotEqual(now.nsDate, originalNsDate)
+    }
+    
+    func testUpdatingDateUpdatesNsDate() {
+        let now = DateTime.now
+        let originalNsDate = now.nsDate
+        
+        now.date = FHIRDate(year: 2017, month: 06, day: 15)
+        let updatedNsDate = now.nsDate
+        XCTAssertNotEqual(originalNsDate, updatedNsDate)
+        
+        now.date!.year = 2015
+        now.date = now.date!
+        print(now.nsDate)
+        XCTAssertNotEqual(updatedNsDate, now.nsDate)
+    }
+    
+    func testUpdatingTimeUpdatesNsDate() {
+        let now = DateTime.now
+        let originalNsDate = now.nsDate
+        now.time = FHIRTime(hour: 15, minute: 7, second: 32)
+        XCTAssertNotEqual(originalNsDate, now.nsDate)
+    }
 }
 
 

--- a/firekit/firekitTests/classes/DateAndTimeTests.swift
+++ b/firekit/firekitTests/classes/DateAndTimeTests.swift
@@ -516,7 +516,6 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 	}
     
     func testTimezoneIsPersistedWhenDateIsSaved() {
-        
         let date = DateTime.now
         
         XCTAssertNotNil(date.time)
@@ -541,10 +540,16 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         XCTAssertNotNil(date2.date)
         XCTAssertNotNil(date2.nsDate)
         XCTAssertNotNil(date2.timeZoneString)
-        XCTAssertNotNil(date2.timeZone) // FAILS
-        XCTAssertEqual(date.nsDate, date2.nsDate) // FAILS
+        XCTAssertNotNil(date2.timeZone)
+        XCTAssertEqual(date.nsDate, date2.nsDate)
         XCTAssertEqual(date, date2)
-        
+    }
+    
+    func testDateTimeNowIsCorrectlySetToLocalTime() {
+        let dtNow = DateTime.now
+        let nsNow = Date()
+        let result = Calendar.current.compare(dtNow.nsDate, to: nsNow, toGranularity: .second)
+        XCTAssertEqual(result, ComparisonResult.orderedSame)
     }
 }
 

--- a/firekit/firekitTests/classes/DateAndTimeTests.swift
+++ b/firekit/firekitTests/classes/DateAndTimeTests.swift
@@ -550,6 +550,13 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         let nsNow = Date()
         let result = Calendar.current.compare(dtNow.nsDate, to: nsNow, toGranularity: .second)
         XCTAssertEqual(result, ComparisonResult.orderedSame)
+        
+        // make sure it's still equal after we re-inflate it from Realm
+        let realm = makeRealm()
+        try! realm.write { realm.add(dtNow) }
+        let dtNow2 = realm.objects(DateTime.self).first!
+        let result2 = Calendar.current.compare(dtNow2.nsDate, to: nsNow, toGranularity: .second)
+        XCTAssertEqual(result2, ComparisonResult.orderedSame)
     }
 }
 

--- a/firekit/firekitTests/classes/DateAndTimeTests.swift
+++ b/firekit/firekitTests/classes/DateAndTimeTests.swift
@@ -232,6 +232,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(2015, d!.date?.year)
 		XCTAssertTrue(nil == d!.date?.month)
 		XCTAssertTrue(nil == d!.time)
+        XCTAssertEqual("2015", d!.description)
 		XCTAssertTrue(nil == d!.timeZone)
 		
 		d = DateTime(string: "2015-03")
@@ -240,6 +241,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(3), d!.date?.month!)
 		XCTAssertTrue(nil == d!.date?.day)
 		XCTAssertTrue(nil == d!.time)
+        XCTAssertEqual("2015-03", d!.description)
 		XCTAssertTrue(nil == d!.timeZone)
 		
 		d = DateTime(string: "2015-03-28")
@@ -248,6 +250,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(3), d!.date?.month!)
 		XCTAssertEqual(Int8(28), d!.date?.day!)
 		XCTAssertTrue(nil == d!.time)
+        XCTAssertEqual("2015-03-28", d!.description)
 		XCTAssertTrue(nil == d!.timeZone)
 		
 		d = DateTime(string: "2015-03-28T02:33")
@@ -283,7 +286,8 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29, d!.time!.second)
-		XCTAssertFalse(nil == d!.timeZone)
+        XCTAssertEqual("2015-03-28T02:33:29+01:00", d!.description)
+        XCTAssertNotNil(d!.timeZone)
 		XCTAssertTrue(3600 == d!.timeZone!.secondsFromGMT(), "Should be 3600 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
 		d = DateTime(string: "2015-03-28T02:33:29-05:00")
@@ -295,6 +299,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29-05:00", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -307,6 +312,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-05:00", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -319,6 +325,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-05:30", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -344,6 +351,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29-05", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -356,6 +364,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-0500", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-18000 == d!.timeZone!.secondsFromGMT(), "Should be 18000 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 		
@@ -368,6 +377,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertEqual(29.1285, d!.time!.second)
+        XCTAssertEqual("2015-03-28T02:33:29.1285-0530", d!.description)
 		XCTAssertFalse(nil == d!.timeZone)
 		XCTAssertTrue(-19800 == d!.timeZone!.secondsFromGMT(), "Should be 19800 seconds ahead, but am \(d!.timeZone!.secondsFromGMT()) seconds")
 	}
@@ -385,7 +395,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         
         XCTAssertEqual(inMemJSON, fetched?.asJSON())
         
-        try! realm.write { fetched?.timeZone = TimeZone(abbreviation: "EDT") }
+        try! realm.write { fetched?.timeZone = TimeZone(abbreviation: "GMT") }
         XCTAssertNotEqual(inMemJSON, fetched?.asJSON())
     }
 
@@ -504,6 +514,38 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		let ns2 = dt2.nsDate
         XCTAssertTrue(dt2 == ns2.fhir_asDateTime(), "Conversion to NSDate and back again must not alter `DateTime`")		
 	}
+    
+    func testTimezoneIsPersistedWhenDateIsSaved() {
+        
+        let date = DateTime.now
+        
+        XCTAssertNotNil(date.time)
+        XCTAssertNotNil(date.date)
+        XCTAssertNotNil(date.nsDate)
+        XCTAssertNotNil(date.timeZoneString)
+        XCTAssertNotNil(date.timeZone)
+        
+        let realm = makeRealm()
+        
+        try! realm.write {
+            realm.add(date)
+        }
+        
+        guard let date2 = realm.objects(DateTime.self).first else {
+            XCTFail("Unable to load persisted date")
+            return
+        }
+        
+        XCTAssertNotNil(date2.time)
+        XCTAssertEqual(date.time, date2.time)
+        XCTAssertNotNil(date2.date)
+        XCTAssertNotNil(date2.nsDate)
+        XCTAssertNotNil(date2.timeZoneString)
+        XCTAssertNotNil(date2.timeZone) // FAILS
+        XCTAssertEqual(date.nsDate, date2.nsDate) // FAILS
+        XCTAssertEqual(date, date2)
+        
+    }
 }
 
 

--- a/firekit/firekitTests/classes/DateAndTimeTests.swift
+++ b/firekit/firekitTests/classes/DateAndTimeTests.swift
@@ -258,7 +258,7 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
 		XCTAssertEqual(2015, d!.date?.year)
 		XCTAssertEqual(Int8(3), d!.date?.month!)
 		XCTAssertEqual(Int8(28), d!.date?.day!)
-		XCTAssertFalse(nil == d!.time)
+        XCTAssertNotNil(d!.time)
 		XCTAssertEqual(Int8(2), d!.time!.hour)
 		XCTAssertEqual(Int8(33), d!.time!.minute)
 		XCTAssertTrue(0 == d!.time!.second)
@@ -561,6 +561,18 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
         let dtNow2 = realm.objects(DateTime.self).first!
         let result2 = Calendar.current.compare(dtNow2.nsDate, to: nsNow, toGranularity: .second)
         XCTAssertEqual(result2, ComparisonResult.orderedSame)
+    }
+    
+    func testNSDateUpdatedWhenDateUpdated() {
+        var newDay: Int8 = 1
+        if Calendar.current.component(.day, from: Date()) == 1 {
+            newDay = 2
+        }
+        
+        let dtNow = DateTime.now
+        let nsDate = dtNow.nsDate
+        dtNow.date?.day = newDay
+        XCTAssertNotEqual(dtNow.nsDate, nsDate)
     }
 }
 

--- a/firekit/firekitTests/classes/DateAndTimeTests.swift
+++ b/firekit/firekitTests/classes/DateAndTimeTests.swift
@@ -517,7 +517,8 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
     
     func testTimezoneIsPersistedWhenDateIsSaved() {
         let date = DateTime.now
-        
+        print("------------")
+        print(Calendar.current.dateComponents([.year, .day, .month, .hour, .day, .second, .nanosecond], from: date.nsDate))
         XCTAssertNotNil(date.time)
         XCTAssertNotNil(date.date)
         XCTAssertNotNil(date.nsDate)
@@ -534,6 +535,9 @@ class DateTimeTests: XCTestCase, RealmPersistenceTesting {
             XCTFail("Unable to load persisted date")
             return
         }
+        
+        print(Calendar.current.dateComponents([.year, .day, .month, .hour, .day, .second, .nanosecond], from: date2.nsDate))
+        print("------------")
         
         XCTAssertNotNil(date2.time)
         XCTAssertEqual(date.time, date2.time)


### PR DESCRIPTION
DateTimes and Instants have been completely restructured such they store
- original date string
- an actual Swift Date object (as `value`) for easier querying
- TimeZone identifier
- TimeZone offset

The old `date: FHIRDate(?)` and `time: FHIRTime(?)` properties which
were persisted have been removed. This bring a cleaner structure to
persistence while also improving the API which now, in essence, behaves
how you would expect it to.