### PR TITLE
Cascade deletes

### DIFF
--- a/firekit/FireKit.xcodeproj/project.pbxproj
+++ b/firekit/FireKit.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		C20D20E61E3A7FB100027316 /* RealmTestingProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20D20E21E3A7BAF00027316 /* RealmTestingProtocols.swift */; };
 		C23F08881E54DA2900B1F9B1 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2AF430D1E37C96C00EE1AEE /* Realm.framework */; };
 		C23F08891E54DA2C00B1F9B1 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2AF430E1E37C96C00EE1AEE /* RealmSwift.framework */; };
+		C2478ADB1F3B712A001A3E67 /* Realm+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2478ADA1F3B712A001A3E67 /* Realm+Extensions.swift */; };
+		C2478ADD1F3B715F001A3E67 /* CascadeDeletableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2478ADC1F3B715F001A3E67 /* CascadeDeletableTests.swift */; };
 		C250E2A81E3808B300C9631E /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF42011E37C6D200EE1AEE /* Account.swift */; };
 		C250E2A91E3808B300C9631E /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF42021E37C6D200EE1AEE /* Address.swift */; };
 		C250E2AA1E3808B300C9631E /* Age.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF42031E37C6D200EE1AEE /* Age.swift */; };
@@ -2934,6 +2936,8 @@
 /* Begin PBXFileReference section */
 		C2018C1F1E5D0BCD00523626 /* Copying.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Copying.swift; path = classes/models/Copying.swift; sourceTree = "<group>"; };
 		C20D20E21E3A7BAF00027316 /* RealmTestingProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmTestingProtocols.swift; path = classes/RealmTestingProtocols.swift; sourceTree = "<group>"; };
+		C2478ADA1F3B712A001A3E67 /* Realm+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Realm+Extensions.swift"; path = "classes/models/Realm+Extensions.swift"; sourceTree = "<group>"; };
+		C2478ADC1F3B715F001A3E67 /* CascadeDeletableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CascadeDeletableTests.swift; path = classes/CascadeDeletableTests.swift; sourceTree = "<group>"; };
 		C2AF41E51E37C4E300EE1AEE /* FireKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FireKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C2AF41E81E37C4E300EE1AEE /* realm-swift-fhir.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "realm-swift-fhir.h"; sourceTree = "<group>"; };
 		C2AF41E91E37C4E300EE1AEE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -5916,7 +5920,6 @@
 		C2AF41FF1E37C50100EE1AEE /* models */ = {
 			isa = PBXGroup;
 			children = (
-				C2018C1F1E5D0BCD00523626 /* Copying.swift */,
 				C2AF42011E37C6D200EE1AEE /* Account.swift */,
 				C2AF42021E37C6D200EE1AEE /* Address.swift */,
 				C2AF42031E37C6D200EE1AEE /* Age.swift */,
@@ -5945,6 +5948,7 @@
 				C2AF421A1E37C6D200EE1AEE /* Conformance.swift */,
 				C2AF421B1E37C6D200EE1AEE /* ContactPoint.swift */,
 				C2AF421C1E37C6D200EE1AEE /* Contract.swift */,
+				C2018C1F1E5D0BCD00523626 /* Copying.swift */,
 				C2AF421D1E37C6D200EE1AEE /* Count.swift */,
 				C2AF421E1E37C6D200EE1AEE /* Coverage.swift */,
 				C2AF421F1E37C6D200EE1AEE /* DataElement.swift */,
@@ -6029,6 +6033,7 @@
 				C2AF426E1E37C6D200EE1AEE /* QuestionnaireResponse.swift */,
 				C2AF426F1E37C6D200EE1AEE /* Range.swift */,
 				C2AF42701E37C6D200EE1AEE /* Ratio.swift */,
+				C2478ADA1F3B712A001A3E67 /* Realm+Extensions.swift */,
 				C2AF42711E37C6D200EE1AEE /* RealmTypes.swift */,
 				C2AF42721E37C6D200EE1AEE /* Reference.swift */,
 				C2AF42731E37C6D200EE1AEE /* ReferralRequest.swift */,
@@ -6151,6 +6156,7 @@
 				C2AF43721E37CCBF00EE1AEE /* ValueSetTests.swift */,
 				C2AF43731E37CCBF00EE1AEE /* VisionPrescriptionTests.swift */,
 				C2AF43741E37CCBF00EE1AEE /* XCTestCase+FHIR.swift */,
+				C2478ADC1F3B715F001A3E67 /* CascadeDeletableTests.swift */,
 			);
 			name = models;
 			sourceTree = "<group>";
@@ -11731,6 +11737,7 @@
 				C250E2BE1E3808B300C9631E /* Composition.swift in Sources */,
 				C250E3251E3808B300C9631E /* Subscription.swift in Sources */,
 				C250E31D1E3808B300C9631E /* RiskAssessment.swift in Sources */,
+				C2478ADB1F3B712A001A3E67 /* Realm+Extensions.swift in Sources */,
 				C250E2F61E3808B300C9631E /* Medication.swift in Sources */,
 				C250E3271E3808B300C9631E /* SupplyDelivery.swift in Sources */,
 				C250E30C1E3808B300C9631E /* Person.swift in Sources */,
@@ -11848,6 +11855,7 @@
 				C2AF43C91E37CCBF00EE1AEE /* StructureDefinitionTests.swift in Sources */,
 				C2AF43B71E37CCBF00EE1AEE /* PaymentNoticeTests.swift in Sources */,
 				C2AF43911E37CCBF00EE1AEE /* DeviceUseStatementTests.swift in Sources */,
+				C2478ADD1F3B715F001A3E67 /* CascadeDeletableTests.swift in Sources */,
 				C2AF43C41E37CCBF00EE1AEE /* RiskAssessmentTests.swift in Sources */,
 				C2AF43CA1E37CCBF00EE1AEE /* SubscriptionTests.swift in Sources */,
 				C2AF43A91E37CCBF00EE1AEE /* MediaTests.swift in Sources */,

--- a/firekit/fhir-parser-resources/fhir-1.6.0/CascadeDeletable.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/CascadeDeletable.swift
@@ -1,0 +1,64 @@
+//
+//  Realm+Extensions.swift
+//  FireKit
+//
+//  Created by Ryan Baldwin on 2017-08-09.
+//  Copyright © 2017 Bunnyhug. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+public protocol CascadeDeletable {
+    func cascadeDelete() throws
+}
+
+extension FHIRAbstractBase: CascadeDeletable {
+    /// Cascade deletes all RealmSwift Objects which are a child of this instance, as well as this instance itself.
+    ///
+    /// - Warning: This method may only be called during a write transaction.
+    public func cascadeDelete() {
+        try! objectSchema.properties.lazy
+            .filter { $0.type == .array }
+            .forEach { property in
+                if let object = value(forKey: property.name) {
+                    try (object as? CascadeDeletable)?.cascadeDelete()
+                }
+        }
+        
+        try! objectSchema.properties.lazy
+            .filter { $0.type == .object }
+            .forEach { property in
+                if let object = value(forKey: property.name) as? RealmSwift.Object {
+                    guard !object.isInvalidated else { return }
+                    
+                    guard let cascadable = object as? CascadeDeletable else {
+                        object.realm?.delete(object)
+                        return
+                    }
+                    
+                    try cascadable.cascadeDelete()
+                }
+        }
+        
+        realm?.delete(self)
+    }
+}
+
+extension RealmSwift.List: CascadeDeletable {
+    
+    /// Iterates through the list and calls `cascadeDelete` on each element, if the element is `CascadeDeletable`,
+    /// otherwise it will attempt to delete the element using the realm managing the element.
+    ///
+    /// - Warning: This method may only be called during a write transaction.
+    public func cascadeDelete() throws {
+        try! forEach { object in
+            guard let cascadable = object as? CascadeDeletable else {
+                object.realm?.delete(object)
+                return
+            }
+            
+            try cascadable.cascadeDelete()
+        }
+    }
+}

--- a/firekit/fhir-parser-resources/fhir-1.6.0/CascadeDeletableTests.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/CascadeDeletableTests.swift
@@ -1,0 +1,66 @@
+//
+//  RealmExtensionTests.swift
+//  FireKit
+//
+//  Created by Ryan Baldwin on 2017-08-09.
+//  Copyright © 2017 Bunnyhug. All rights reserved.
+//
+
+import XCTest
+import Foundation
+import FireKit
+import RealmSwift
+
+class CascadeDeletableTests: XCTestCase, RealmPersistenceTesting {
+    var realm: Realm!
+    
+    override func setUp() {
+        realm = makeRealm()
+    }
+    
+    func testCanDeleteUnmanagedResource() {
+        let patient = Patient()
+        patient.cascadeDelete()
+    }
+    
+    func testCanDeleteManagedResource() {
+        let patient = Patient()
+        try! realm.write { realm.add(patient) }
+        XCTAssertNotNil(realm.objects(Patient.self).first)
+        
+        try! realm.write { patient.cascadeDelete() }
+        XCTAssertNil(realm.objects(Patient.self).first)
+    }
+    
+    func testCanDeleteChildRelationship() {
+        let patient = Patient()
+        patient.animal = PatientAnimal()
+        
+        try! realm.write { realm.add(patient) }
+        XCTAssertNotNil(realm.objects(Patient.self).first)
+        XCTAssertNotNil(realm.objects(PatientAnimal.self).first)
+        
+        try! realm.write { patient.cascadeDelete() }
+        XCTAssertNil(realm.objects(Patient.self).first)
+        XCTAssertNil(realm.objects(PatientAnimal.self).first)
+    }
+    
+    func testCanDeleteChildLists() {
+        let patient = Patient()
+        
+        let name = HumanName()
+        name.family.append(RealmString(val: "Baldwin"))
+        name.given.append(RealmString(val: "Ryan"))
+        patient.name.append(name)
+        
+        try! realm.write { realm.add(patient) }
+        XCTAssertNotNil(realm.objects(Patient.self).first)
+        XCTAssertNotNil(realm.objects(HumanName.self).first)
+        XCTAssertEqual(realm.objects(RealmString.self).count, 2)
+        
+        try! realm.write { patient.cascadeDelete() }
+        XCTAssertEqual(realm.objects(RealmString.self).count, 0)
+        XCTAssertNil(realm.objects(HumanName.self).first)
+        XCTAssertNil(realm.objects(Patient.self).first)
+    }
+}

--- a/firekit/fhir-parser-resources/fhir-1.6.0/settings.py
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/settings.py
@@ -45,6 +45,7 @@ manual_profiles = [                                     # all these profiles sho
     (tpl_source + '/DateAndTime.swift', None, [
         'date', 'dateTime', 'time', 'instant',
     ]),
+    (tpl_source + '/CascadeDeletable.swift', None, [])
     (tpl_source + '/JSON-extensions.swift', None, []),
     (tpl_source + '/FHIRServer.swift', None, []),
     (tpl_source + '/FHIRServerResponse.swift', None, []),
@@ -67,7 +68,8 @@ tpl_unittest_source = tpl_source + '/template-unittest.swift'
 unittest_copyfiles = [
     tpl_source + '/XCTestCase+FHIR.swift',
     tpl_source + '/DateAndTimeTests.swift',
-    tpl_source + '/RealmTestingProtocols.swift'
+    tpl_source + '/RealmTestingProtocols.swift',
+    tpl_source + '/CascadeDeletableTests.swift'
 ]
 unittest_format_path_prepare = '{}?'            # used to format `path` before appending another path element - one placeholder for `path`
 unittest_format_path_key = '{}.{}'              # used to create property paths by appending `key` to the existing `path` - two placeholders

--- a/firekit/firekit/classes/models/Realm+Extensions.swift
+++ b/firekit/firekit/classes/models/Realm+Extensions.swift
@@ -1,0 +1,63 @@
+//
+//  Realm+Extensions.swift
+//  FireKit
+//
+//  Created by Ryan Baldwin on 2017-08-09.
+//  Copyright © 2017 Bunnyhug. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+public protocol CascadeDeletable {
+    func cascadeDelete() throws
+}
+
+extension FHIRAbstractBase: CascadeDeletable {
+    /// Cascade deletes all RealmSwift Objects which are a child of this instance, as well as this instance itself.
+    ///
+    /// - Warning: This method may only be called during a write transaction.
+    public func cascadeDelete() {
+        try! objectSchema.properties.lazy
+            .filter { $0.type == .array }
+            .forEach { property in
+                if let object = value(forKey: property.name) {
+                    try (object as? CascadeDeletable)?.cascadeDelete()
+                }
+        }
+        
+        try! objectSchema.properties.lazy
+            .filter { $0.type == .object }
+            .forEach { property in
+                if let object = value(forKey: property.name) as? RealmSwift.Object {
+                    guard !object.isInvalidated else { return }
+                    
+                    guard let cascadable = object as? CascadeDeletable else {
+                        object.realm?.delete(object)
+                        return
+                    }
+                    
+                    try cascadable.cascadeDelete()
+                }
+        }
+        
+        realm?.delete(self)
+    }
+}
+
+extension RealmSwift.List: CascadeDeletable {
+    
+    /// Iterates through the list and calls `cascadeDelete` on each element.
+    ///
+    /// - Warning: This method may only be called during a write transaction.
+    public func cascadeDelete() throws {
+        try! forEach { object in
+            guard let cascadable = object as? CascadeDeletable else {
+                object.realm?.delete(object)
+                return
+            }
+            
+            try cascadable.cascadeDelete()
+        }
+    }
+}

--- a/firekit/firekit/classes/models/Realm+Extensions.swift
+++ b/firekit/firekit/classes/models/Realm+Extensions.swift
@@ -47,7 +47,8 @@ extension FHIRAbstractBase: CascadeDeletable {
 
 extension RealmSwift.List: CascadeDeletable {
     
-    /// Iterates through the list and calls `cascadeDelete` on each element.
+    /// Iterates through the list and calls `cascadeDelete` on each element, if the element is `CascadeDeletable`,
+    /// otherwise it will attempt to delete the element using the realm managing the element.
     ///
     /// - Warning: This method may only be called during a write transaction.
     public func cascadeDelete() throws {

--- a/firekit/firekitTests/classes/CascadeDeletableTests.swift
+++ b/firekit/firekitTests/classes/CascadeDeletableTests.swift
@@ -1,0 +1,66 @@
+//
+//  RealmExtensionTests.swift
+//  FireKit
+//
+//  Created by Ryan Baldwin on 2017-08-09.
+//  Copyright © 2017 Bunnyhug. All rights reserved.
+//
+
+import XCTest
+import Foundation
+import FireKit
+import RealmSwift
+
+class CascadeDeletableTests: XCTestCase, RealmPersistenceTesting {
+    var realm: Realm!
+    
+    override func setUp() {
+        realm = makeRealm()
+    }
+    
+    func testCanDeleteUnmanagedResource() {
+        let patient = Patient()
+        patient.cascadeDelete()
+    }
+    
+    func testCanDeleteManagedResource() {
+        let patient = Patient()
+        try! realm.write { realm.add(patient) }
+        XCTAssertNotNil(realm.objects(Patient.self).first)
+        
+        try! realm.write { patient.cascadeDelete() }
+        XCTAssertNil(realm.objects(Patient.self).first)
+    }
+    
+    func testCanDeleteChildRelationship() {
+        let patient = Patient()
+        patient.animal = PatientAnimal()
+        
+        try! realm.write { realm.add(patient) }
+        XCTAssertNotNil(realm.objects(Patient.self).first)
+        XCTAssertNotNil(realm.objects(PatientAnimal.self).first)
+        
+        try! realm.write { patient.cascadeDelete() }
+        XCTAssertNil(realm.objects(Patient.self).first)
+        XCTAssertNil(realm.objects(PatientAnimal.self).first)
+    }
+    
+    func testCanDeleteChildLists() {
+        let patient = Patient()
+        
+        let name = HumanName()
+        name.family.append(RealmString(val: "Baldwin"))
+        name.given.append(RealmString(val: "Ryan"))
+        patient.name.append(name)
+        
+        try! realm.write { realm.add(patient) }
+        XCTAssertNotNil(realm.objects(Patient.self).first)
+        XCTAssertNotNil(realm.objects(HumanName.self).first)
+        XCTAssertEqual(realm.objects(RealmString.self).count, 2)
+        
+        try! realm.write { patient.cascadeDelete() }
+        XCTAssertEqual(realm.objects(RealmString.self).count, 0)
+        XCTAssertNil(realm.objects(HumanName.self).first)
+        XCTAssertNil(realm.objects(Patient.self).first)
+    }
+}


### PR DESCRIPTION
`FHIRAbstractBase` items (realistically, `Resource` and `Element` objects) can now be cascade deleted, thus removing the requirement to manually manage all child relationships post removal. Realm, by its nature, will orphan these items as opposed to deleting them. Given that FHIR resources are "self encapsulated", using the `cascadeDelete` on these items can save some headaches (or introduce some monster ones)