### PR TITLE
Fixed populateFrom and upsert

### DIFF
--- a/firekit/FireKit.xcodeproj/project.pbxproj
+++ b/firekit/FireKit.xcodeproj/project.pbxproj
@@ -2921,6 +2921,7 @@
 		C2AF6DAE1E37D5C000EE1AEE /* xdsdocumentreference-questionnaire.canonical.json in Resources */ = {isa = PBXBuildFile; fileRef = C2AF63371E37D5BB00EE1AEE /* xdsdocumentreference-questionnaire.canonical.json */; };
 		C2AF6DAF1E37D5C000EE1AEE /* xdsdocumentreference-questionnaire.json in Resources */ = {isa = PBXBuildFile; fileRef = C2AF63381E37D5BB00EE1AEE /* xdsdocumentreference-questionnaire.json */; };
 		C2AF6DB01E37D5C000EE1AEE /* xdsdocumentreference.profile.json in Resources */ = {isa = PBXBuildFile; fileRef = C2AF63391E37D5BB00EE1AEE /* xdsdocumentreference.profile.json */; };
+		C2E0C73E1FB35DCB00F3B14D /* FHIRAbstractBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E0C73D1FB35DCB00F3B14D /* FHIRAbstractBaseTests.swift */; };
 		C2FFA2B11F7147EC0052021D /* PopulatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FFA2B01F7147EC0052021D /* PopulatableTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -5852,6 +5853,7 @@
 		C2AF63371E37D5BB00EE1AEE /* xdsdocumentreference-questionnaire.canonical.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "xdsdocumentreference-questionnaire.canonical.json"; sourceTree = "<group>"; };
 		C2AF63381E37D5BB00EE1AEE /* xdsdocumentreference-questionnaire.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "xdsdocumentreference-questionnaire.json"; sourceTree = "<group>"; };
 		C2AF63391E37D5BB00EE1AEE /* xdsdocumentreference.profile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = xdsdocumentreference.profile.json; sourceTree = "<group>"; };
+		C2E0C73D1FB35DCB00F3B14D /* FHIRAbstractBaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRAbstractBaseTests.swift; sourceTree = "<group>"; };
 		C2FFA2B01F7147EC0052021D /* PopulatableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopulatableTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -6167,6 +6169,7 @@
 				C2AF43731E37CCBF00EE1AEE /* VisionPrescriptionTests.swift */,
 				C2AF43741E37CCBF00EE1AEE /* XCTestCase+FHIR.swift */,
 				C2ADFE8C1F86C8E0005DFF45 /* RealmUpsertTests.swift */,
+				C2E0C73D1FB35DCB00F3B14D /* FHIRAbstractBaseTests.swift */,
 			);
 			name = models;
 			sourceTree = "<group>";
@@ -11844,6 +11847,7 @@
 				C2AF438A1E37CCBF00EE1AEE /* DataElementTests.swift in Sources */,
 				C2AF43901E37CCBF00EE1AEE /* DeviceUseRequestTests.swift in Sources */,
 				C2AF43761E37CCBF00EE1AEE /* AllergyIntoleranceTests.swift in Sources */,
+				C2E0C73E1FB35DCB00F3B14D /* FHIRAbstractBaseTests.swift in Sources */,
 				C2AF43861E37CCBF00EE1AEE /* ConditionTests.swift in Sources */,
 				C2AF43851E37CCBF00EE1AEE /* ConceptMapTests.swift in Sources */,
 				C2AF43891E37CCBF00EE1AEE /* CoverageTests.swift in Sources */,

--- a/firekit/fhir-parser-resources/fhir-1.6.0/swift-4.0/FHIRAbstractBase.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/swift-4.0/FHIRAbstractBase.swift
@@ -43,46 +43,30 @@ open class FHIRAbstractBase: Object, Codable, NSCopying, Populatable {
 
     // MARK: - Realm Element convenience method
     func upsert<T: Element>(prop: inout T?, val: T?) {
-        if prop != nil && val != nil {
-            prop!.populate(from: val! as Any)
-            return
-        }
-        
-        if prop != nil && val == nil {
-            guard let r = realm else {
-                prop?.cascadeDelete()
-                prop = nil
-                return
-            }
-            
-            r.delete(prop!)
+        guard let value = val else {
+            prop?.cascadeDelete()
             prop = nil
             return
         }
-
-        prop = val
+        
+        if prop == nil {
+            prop = T.init()
+        }
+        prop?.populate(from: value as Any)
     }
 
     // ugh, this is so lame.
     func upsert<T: Resource>(prop: inout T?, val: T?) {
-        if prop != nil && val != nil {
-            prop!.populate(from: val! as Any)
-            return
-        }
-        
-        if prop != nil && val == nil {
-            guard let r = realm else {
-                prop?.cascadeDelete()
-                prop = nil
-                return
-            }
-            
-            r.delete(prop!)
+        guard let value = val else {
+            prop?.cascadeDelete()
             prop = nil
             return
         }
         
-        prop = val
+        if prop == nil {
+            prop = T.init()
+        }
+        prop?.populate(from: value as Any)
     }
 
     public func copy(with zone: NSZone? = nil) -> Any {

--- a/firekit/fhir-parser-resources/fhir-1.6.0/swift-4.0/RealmTypes.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/swift-4.0/RealmTypes.swift
@@ -267,4 +267,17 @@ final public class ContainedResource: Resource {
         resourceType = o.resourceType
         json = o.json
     }
+
+    
+    public override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = ContainedResource()
+        copy._versionId = _versionId
+        copy.id = id
+        copy.implicitRules = implicitRules
+        copy.language = language
+        copy.upsert(meta: meta)
+        copy.resourceType = resourceType
+        copy.json = json
+        return copy
+    }
 }

--- a/firekit/fhir-parser-resources/fhir-1.6.0/swift-4.0/template-resource-populatable.swift
+++ b/firekit/fhir-parser-resources/fhir-1.6.0/swift-4.0/template-resource-populatable.swift
@@ -11,7 +11,11 @@
 
         for (index, t) in o.{{prop.name}}.enumerated() {
             guard index < self.{{prop.name}}.count else {
-                self.{{prop.name}}.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = {{prop|realm_listify}}()
+                val.populate(from: t)
+                self.{{prop.name}}.append(val)
                 continue
             }
             self.{{prop.name}}[index].populate(from: t)

--- a/firekit/firekit/classes/models/Account.swift
+++ b/firekit/firekit/classes/models/Account.swift
@@ -2,10 +2,10 @@
 //  Account.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Account) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Account) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -143,7 +143,11 @@ open class Account: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Address.swift
+++ b/firekit/firekit/classes/models/Address.swift
@@ -2,10 +2,10 @@
 //  Address.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Address) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Address) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -119,7 +119,11 @@ open class Address: Element {
 
         for (index, t) in o.line.enumerated() {
             guard index < self.line.count else {
-                self.line.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.line.append(val)
                 continue
             }
             self.line[index].populate(from: t)

--- a/firekit/firekit/classes/models/Age.swift
+++ b/firekit/firekit/classes/models/Age.swift
@@ -2,10 +2,10 @@
 //  Age.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Age) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Age) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/AllergyIntolerance.swift
+++ b/firekit/firekit/classes/models/AllergyIntolerance.swift
@@ -2,10 +2,10 @@
 //  AllergyIntolerance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AllergyIntolerance) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AllergyIntolerance) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -153,7 +153,11 @@ open class AllergyIntolerance: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -171,7 +175,11 @@ open class AllergyIntolerance: DomainResource {
 
         for (index, t) in o.reaction.enumerated() {
             guard index < self.reaction.count else {
-                self.reaction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = AllergyIntoleranceReaction()
+                val.populate(from: t)
+                self.reaction.append(val)
                 continue
             }
             self.reaction[index].populate(from: t)
@@ -301,7 +309,11 @@ open class AllergyIntoleranceReaction: BackboneElement {
 
         for (index, t) in o.manifestation.enumerated() {
             guard index < self.manifestation.count else {
-                self.manifestation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.manifestation.append(val)
                 continue
             }
             self.manifestation[index].populate(from: t)

--- a/firekit/firekit/classes/models/Annotation.swift
+++ b/firekit/firekit/classes/models/Annotation.swift
@@ -2,10 +2,10 @@
 //  Annotation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Annotation) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Annotation) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Appointment.swift
+++ b/firekit/firekit/classes/models/Appointment.swift
@@ -2,10 +2,10 @@
 //  Appointment.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Appointment) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Appointment) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -135,7 +135,11 @@ open class Appointment: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -150,7 +154,11 @@ open class Appointment: DomainResource {
 
         for (index, t) in o.participant.enumerated() {
             guard index < self.participant.count else {
-                self.participant.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = AppointmentParticipant()
+                val.populate(from: t)
+                self.participant.append(val)
                 continue
             }
             self.participant[index].populate(from: t)
@@ -166,7 +174,11 @@ open class Appointment: DomainResource {
 
         for (index, t) in o.slot.enumerated() {
             guard index < self.slot.count else {
-                self.slot.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.slot.append(val)
                 continue
             }
             self.slot[index].populate(from: t)
@@ -271,7 +283,11 @@ open class AppointmentParticipant: BackboneElement {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)

--- a/firekit/firekit/classes/models/AppointmentResponse.swift
+++ b/firekit/firekit/classes/models/AppointmentResponse.swift
@@ -2,10 +2,10 @@
 //  AppointmentResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AppointmentResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AppointmentResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -119,7 +119,11 @@ open class AppointmentResponse: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -134,7 +138,11 @@ open class AppointmentResponse: DomainResource {
 
         for (index, t) in o.participantType.enumerated() {
             guard index < self.participantType.count else {
-                self.participantType.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.participantType.append(val)
                 continue
             }
             self.participantType[index].populate(from: t)

--- a/firekit/firekit/classes/models/Attachment.swift
+++ b/firekit/firekit/classes/models/Attachment.swift
@@ -2,10 +2,10 @@
 //  Attachment.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Attachment) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Attachment) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/AuditEvent.swift
+++ b/firekit/firekit/classes/models/AuditEvent.swift
@@ -2,10 +2,10 @@
 //  AuditEvent.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AuditEvent) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/AuditEvent) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -104,7 +104,11 @@ open class AuditEvent: DomainResource {
 
         for (index, t) in o.object.enumerated() {
             guard index < self.object.count else {
-                self.object.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = AuditEventObject()
+                val.populate(from: t)
+                self.object.append(val)
                 continue
             }
             self.object[index].populate(from: t)
@@ -118,7 +122,11 @@ open class AuditEvent: DomainResource {
 
         for (index, t) in o.participant.enumerated() {
             guard index < self.participant.count else {
-                self.participant.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = AuditEventParticipant()
+                val.populate(from: t)
+                self.participant.append(val)
                 continue
             }
             self.participant[index].populate(from: t)
@@ -235,7 +243,11 @@ open class AuditEventEvent: BackboneElement {
 
         for (index, t) in o.purposeOfEvent.enumerated() {
             guard index < self.purposeOfEvent.count else {
-                self.purposeOfEvent.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.purposeOfEvent.append(val)
                 continue
             }
             self.purposeOfEvent[index].populate(from: t)
@@ -249,7 +261,11 @@ open class AuditEventEvent: BackboneElement {
 
         for (index, t) in o.subtype.enumerated() {
             guard index < self.subtype.count else {
-                self.subtype.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.subtype.append(val)
                 continue
             }
             self.subtype[index].populate(from: t)
@@ -378,7 +394,11 @@ open class AuditEventObject: BackboneElement {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = AuditEventObjectDetail()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -398,7 +418,11 @@ open class AuditEventObject: BackboneElement {
 
         for (index, t) in o.securityLabel.enumerated() {
             guard index < self.securityLabel.count else {
-                self.securityLabel.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.securityLabel.append(val)
                 continue
             }
             self.securityLabel[index].populate(from: t)
@@ -616,7 +640,11 @@ open class AuditEventParticipant: BackboneElement {
 
         for (index, t) in o.policy.enumerated() {
             guard index < self.policy.count else {
-                self.policy.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.policy.append(val)
                 continue
             }
             self.policy[index].populate(from: t)
@@ -630,7 +658,11 @@ open class AuditEventParticipant: BackboneElement {
 
         for (index, t) in o.purposeOfUse.enumerated() {
             guard index < self.purposeOfUse.count else {
-                self.purposeOfUse.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.purposeOfUse.append(val)
                 continue
             }
             self.purposeOfUse[index].populate(from: t)
@@ -646,7 +678,11 @@ open class AuditEventParticipant: BackboneElement {
 
         for (index, t) in o.role.enumerated() {
             guard index < self.role.count else {
-                self.role.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.role.append(val)
                 continue
             }
             self.role[index].populate(from: t)
@@ -812,7 +848,11 @@ open class AuditEventSource: BackboneElement {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)

--- a/firekit/firekit/classes/models/BackboneElement.swift
+++ b/firekit/firekit/classes/models/BackboneElement.swift
@@ -2,10 +2,10 @@
 //  BackboneElement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BackboneElement) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BackboneElement) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -76,7 +76,11 @@ open class BackboneElement: Element {
 
         for (index, t) in o.modifierExtension.enumerated() {
             guard index < self.modifierExtension.count else {
-                self.modifierExtension.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Extension()
+                val.populate(from: t)
+                self.modifierExtension.append(val)
                 continue
             }
             self.modifierExtension[index].populate(from: t)

--- a/firekit/firekit/classes/models/Basic.swift
+++ b/firekit/firekit/classes/models/Basic.swift
@@ -2,10 +2,10 @@
 //  Basic.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Basic) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Basic) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -111,7 +111,11 @@ open class Basic: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Binary.swift
+++ b/firekit/firekit/classes/models/Binary.swift
@@ -2,10 +2,10 @@
 //  Binary.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Binary) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Binary) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/BodySite.swift
+++ b/firekit/firekit/classes/models/BodySite.swift
@@ -2,10 +2,10 @@
 //  BodySite.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BodySite) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/BodySite) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -111,7 +111,11 @@ open class BodySite: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -125,7 +129,11 @@ open class BodySite: DomainResource {
 
         for (index, t) in o.image.enumerated() {
             guard index < self.image.count else {
-                self.image.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Attachment()
+                val.populate(from: t)
+                self.image.append(val)
                 continue
             }
             self.image[index].populate(from: t)
@@ -139,7 +147,11 @@ open class BodySite: DomainResource {
 
         for (index, t) in o.modifier.enumerated() {
             guard index < self.modifier.count else {
-                self.modifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.modifier.append(val)
                 continue
             }
             self.modifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Bundle.swift
+++ b/firekit/firekit/classes/models/Bundle.swift
@@ -2,10 +2,10 @@
 //  Bundle.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Bundle) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Bundle) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -101,7 +101,11 @@ open class Bundle: Resource {
 
         for (index, t) in o.entry.enumerated() {
             guard index < self.entry.count else {
-                self.entry.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = BundleEntry()
+                val.populate(from: t)
+                self.entry.append(val)
                 continue
             }
             self.entry[index].populate(from: t)
@@ -115,7 +119,11 @@ open class Bundle: Resource {
 
         for (index, t) in o.link.enumerated() {
             guard index < self.link.count else {
-                self.link.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = BundleLink()
+                val.populate(from: t)
+                self.link.append(val)
                 continue
             }
             self.link[index].populate(from: t)
@@ -234,7 +242,11 @@ open class BundleEntry: BackboneElement {
 
         for (index, t) in o.link.enumerated() {
             guard index < self.link.count else {
-                self.link.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = BundleLink()
+                val.populate(from: t)
+                self.link.append(val)
                 continue
             }
             self.link[index].populate(from: t)

--- a/firekit/firekit/classes/models/CarePlan.swift
+++ b/firekit/firekit/classes/models/CarePlan.swift
@@ -2,10 +2,10 @@
 //  CarePlan.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CarePlan) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CarePlan) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -155,7 +155,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.activity.enumerated() {
             guard index < self.activity.count else {
-                self.activity.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CarePlanActivity()
+                val.populate(from: t)
+                self.activity.append(val)
                 continue
             }
             self.activity[index].populate(from: t)
@@ -169,7 +173,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.addresses.enumerated() {
             guard index < self.addresses.count else {
-                self.addresses.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.addresses.append(val)
                 continue
             }
             self.addresses[index].populate(from: t)
@@ -183,7 +191,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.author.enumerated() {
             guard index < self.author.count else {
-                self.author.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.author.append(val)
                 continue
             }
             self.author[index].populate(from: t)
@@ -197,7 +209,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.category.enumerated() {
             guard index < self.category.count else {
-                self.category.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.category.append(val)
                 continue
             }
             self.category[index].populate(from: t)
@@ -213,7 +229,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.goal.enumerated() {
             guard index < self.goal.count else {
-                self.goal.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.goal.append(val)
                 continue
             }
             self.goal[index].populate(from: t)
@@ -227,7 +247,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -243,7 +267,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.participant.enumerated() {
             guard index < self.participant.count else {
-                self.participant.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CarePlanParticipant()
+                val.populate(from: t)
+                self.participant.append(val)
                 continue
             }
             self.participant[index].populate(from: t)
@@ -258,7 +286,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.relatedPlan.enumerated() {
             guard index < self.relatedPlan.count else {
-                self.relatedPlan.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CarePlanRelatedPlan()
+                val.populate(from: t)
+                self.relatedPlan.append(val)
                 continue
             }
             self.relatedPlan[index].populate(from: t)
@@ -274,7 +306,11 @@ open class CarePlan: DomainResource {
 
         for (index, t) in o.support.enumerated() {
             guard index < self.support.count else {
-                self.support.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.support.append(val)
                 continue
             }
             self.support[index].populate(from: t)
@@ -371,7 +407,11 @@ open class CarePlanActivity: BackboneElement {
 
         for (index, t) in o.actionResulting.enumerated() {
             guard index < self.actionResulting.count else {
-                self.actionResulting.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.actionResulting.append(val)
                 continue
             }
             self.actionResulting[index].populate(from: t)
@@ -386,7 +426,11 @@ open class CarePlanActivity: BackboneElement {
 
         for (index, t) in o.progress.enumerated() {
             guard index < self.progress.count else {
-                self.progress.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.progress.append(val)
                 continue
             }
             self.progress[index].populate(from: t)
@@ -574,7 +618,11 @@ open class CarePlanActivityDetail: BackboneElement {
 
         for (index, t) in o.goal.enumerated() {
             guard index < self.goal.count else {
-                self.goal.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.goal.append(val)
                 continue
             }
             self.goal[index].populate(from: t)
@@ -589,7 +637,11 @@ open class CarePlanActivityDetail: BackboneElement {
 
         for (index, t) in o.performer.enumerated() {
             guard index < self.performer.count else {
-                self.performer.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.performer.append(val)
                 continue
             }
             self.performer[index].populate(from: t)
@@ -607,7 +659,11 @@ open class CarePlanActivityDetail: BackboneElement {
 
         for (index, t) in o.reasonCode.enumerated() {
             guard index < self.reasonCode.count else {
-                self.reasonCode.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reasonCode.append(val)
                 continue
             }
             self.reasonCode[index].populate(from: t)
@@ -621,7 +677,11 @@ open class CarePlanActivityDetail: BackboneElement {
 
         for (index, t) in o.reasonReference.enumerated() {
             guard index < self.reasonReference.count else {
-                self.reasonReference.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.reasonReference.append(val)
                 continue
             }
             self.reasonReference[index].populate(from: t)

--- a/firekit/firekit/classes/models/Claim.swift
+++ b/firekit/firekit/classes/models/Claim.swift
@@ -2,10 +2,10 @@
 //  Claim.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Claim) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Claim) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -243,7 +243,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.additionalMaterials.enumerated() {
             guard index < self.additionalMaterials.count else {
-                self.additionalMaterials.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.additionalMaterials.append(val)
                 continue
             }
             self.additionalMaterials[index].populate(from: t)
@@ -257,7 +261,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.condition.enumerated() {
             guard index < self.condition.count else {
-                self.condition.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.condition.append(val)
                 continue
             }
             self.condition[index].populate(from: t)
@@ -271,7 +279,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.coverage.enumerated() {
             guard index < self.coverage.count else {
-                self.coverage.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimCoverage()
+                val.populate(from: t)
+                self.coverage.append(val)
                 continue
             }
             self.coverage[index].populate(from: t)
@@ -286,7 +298,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.diagnosis.enumerated() {
             guard index < self.diagnosis.count else {
-                self.diagnosis.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimDiagnosis()
+                val.populate(from: t)
+                self.diagnosis.append(val)
                 continue
             }
             self.diagnosis[index].populate(from: t)
@@ -301,7 +317,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.exception.enumerated() {
             guard index < self.exception.count else {
-                self.exception.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.exception.append(val)
                 continue
             }
             self.exception[index].populate(from: t)
@@ -317,7 +337,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -331,7 +355,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.interventionException.enumerated() {
             guard index < self.interventionException.count else {
-                self.interventionException.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.interventionException.append(val)
                 continue
             }
             self.interventionException[index].populate(from: t)
@@ -345,7 +373,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.item.enumerated() {
             guard index < self.item.count else {
-                self.item.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimItem()
+                val.populate(from: t)
+                self.item.append(val)
                 continue
             }
             self.item[index].populate(from: t)
@@ -359,7 +391,11 @@ open class Claim: DomainResource {
 
         for (index, t) in o.missingTeeth.enumerated() {
             guard index < self.missingTeeth.count else {
-                self.missingTeeth.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimMissingTeeth()
+                val.populate(from: t)
+                self.missingTeeth.append(val)
                 continue
             }
             self.missingTeeth[index].populate(from: t)
@@ -505,7 +541,11 @@ open class ClaimCoverage: BackboneElement {
 
         for (index, t) in o.preAuthRef.enumerated() {
             guard index < self.preAuthRef.count else {
-                self.preAuthRef.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.preAuthRef.append(val)
                 continue
             }
             self.preAuthRef[index].populate(from: t)
@@ -765,7 +805,11 @@ open class ClaimItem: BackboneElement {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimItemDetail()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -779,7 +823,11 @@ open class ClaimItem: BackboneElement {
 
         for (index, t) in o.diagnosisLinkId.enumerated() {
             guard index < self.diagnosisLinkId.count else {
-                self.diagnosisLinkId.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmInt()
+                val.populate(from: t)
+                self.diagnosisLinkId.append(val)
                 continue
             }
             self.diagnosisLinkId[index].populate(from: t)
@@ -794,7 +842,11 @@ open class ClaimItem: BackboneElement {
 
         for (index, t) in o.modifier.enumerated() {
             guard index < self.modifier.count else {
-                self.modifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.modifier.append(val)
                 continue
             }
             self.modifier[index].populate(from: t)
@@ -816,7 +868,11 @@ open class ClaimItem: BackboneElement {
 
         for (index, t) in o.subSite.enumerated() {
             guard index < self.subSite.count else {
-                self.subSite.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.subSite.append(val)
                 continue
             }
             self.subSite[index].populate(from: t)
@@ -965,7 +1021,11 @@ open class ClaimItemDetail: BackboneElement {
 
         for (index, t) in o.subDetail.enumerated() {
             guard index < self.subDetail.count else {
-                self.subDetail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimItemDetailSubDetail()
+                val.populate(from: t)
+                self.subDetail.append(val)
                 continue
             }
             self.subDetail[index].populate(from: t)

--- a/firekit/firekit/classes/models/ClaimResponse.swift
+++ b/firekit/firekit/classes/models/ClaimResponse.swift
@@ -2,10 +2,10 @@
 //  ClaimResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClaimResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClaimResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -224,7 +224,11 @@ open class ClaimResponse: DomainResource {
 
         for (index, t) in o.addItem.enumerated() {
             guard index < self.addItem.count else {
-                self.addItem.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseAddItem()
+                val.populate(from: t)
+                self.addItem.append(val)
                 continue
             }
             self.addItem[index].populate(from: t)
@@ -238,7 +242,11 @@ open class ClaimResponse: DomainResource {
 
         for (index, t) in o.coverage.enumerated() {
             guard index < self.coverage.count else {
-                self.coverage.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseCoverage()
+                val.populate(from: t)
+                self.coverage.append(val)
                 continue
             }
             self.coverage[index].populate(from: t)
@@ -254,7 +262,11 @@ open class ClaimResponse: DomainResource {
 
         for (index, t) in o.error.enumerated() {
             guard index < self.error.count else {
-                self.error.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseError()
+                val.populate(from: t)
+                self.error.append(val)
                 continue
             }
             self.error[index].populate(from: t)
@@ -269,7 +281,11 @@ open class ClaimResponse: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -283,7 +299,11 @@ open class ClaimResponse: DomainResource {
 
         for (index, t) in o.item.enumerated() {
             guard index < self.item.count else {
-                self.item.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseItem()
+                val.populate(from: t)
+                self.item.append(val)
                 continue
             }
             self.item[index].populate(from: t)
@@ -297,7 +317,11 @@ open class ClaimResponse: DomainResource {
 
         for (index, t) in o.note.enumerated() {
             guard index < self.note.count else {
-                self.note.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseNote()
+                val.populate(from: t)
+                self.note.append(val)
                 continue
             }
             self.note[index].populate(from: t)
@@ -424,7 +448,11 @@ open class ClaimResponseAddItem: BackboneElement {
 
         for (index, t) in o.adjudication.enumerated() {
             guard index < self.adjudication.count else {
-                self.adjudication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseAddItemAdjudication()
+                val.populate(from: t)
+                self.adjudication.append(val)
                 continue
             }
             self.adjudication[index].populate(from: t)
@@ -438,7 +466,11 @@ open class ClaimResponseAddItem: BackboneElement {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseAddItemDetail()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -453,7 +485,11 @@ open class ClaimResponseAddItem: BackboneElement {
 
         for (index, t) in o.noteNumberLinkId.enumerated() {
             guard index < self.noteNumberLinkId.count else {
-                self.noteNumberLinkId.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmInt()
+                val.populate(from: t)
+                self.noteNumberLinkId.append(val)
                 continue
             }
             self.noteNumberLinkId[index].populate(from: t)
@@ -467,7 +503,11 @@ open class ClaimResponseAddItem: BackboneElement {
 
         for (index, t) in o.sequenceLinkId.enumerated() {
             guard index < self.sequenceLinkId.count else {
-                self.sequenceLinkId.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmInt()
+                val.populate(from: t)
+                self.sequenceLinkId.append(val)
                 continue
             }
             self.sequenceLinkId[index].populate(from: t)
@@ -653,7 +693,11 @@ open class ClaimResponseAddItemDetail: BackboneElement {
 
         for (index, t) in o.adjudication.enumerated() {
             guard index < self.adjudication.count else {
-                self.adjudication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseAddItemDetailAdjudication()
+                val.populate(from: t)
+                self.adjudication.append(val)
                 continue
             }
             self.adjudication[index].populate(from: t)
@@ -874,7 +918,11 @@ open class ClaimResponseCoverage: BackboneElement {
 
         for (index, t) in o.preAuthRef.enumerated() {
             guard index < self.preAuthRef.count else {
-                self.preAuthRef.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.preAuthRef.append(val)
                 continue
             }
             self.preAuthRef[index].populate(from: t)
@@ -1061,7 +1109,11 @@ open class ClaimResponseItem: BackboneElement {
 
         for (index, t) in o.adjudication.enumerated() {
             guard index < self.adjudication.count else {
-                self.adjudication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseItemAdjudication()
+                val.populate(from: t)
+                self.adjudication.append(val)
                 continue
             }
             self.adjudication[index].populate(from: t)
@@ -1075,7 +1127,11 @@ open class ClaimResponseItem: BackboneElement {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseItemDetail()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -1089,7 +1145,11 @@ open class ClaimResponseItem: BackboneElement {
 
         for (index, t) in o.noteNumber.enumerated() {
             guard index < self.noteNumber.count else {
-                self.noteNumber.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmInt()
+                val.populate(from: t)
+                self.noteNumber.append(val)
                 continue
             }
             self.noteNumber[index].populate(from: t)
@@ -1269,7 +1329,11 @@ open class ClaimResponseItemDetail: BackboneElement {
 
         for (index, t) in o.adjudication.enumerated() {
             guard index < self.adjudication.count else {
-                self.adjudication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseItemDetailAdjudication()
+                val.populate(from: t)
+                self.adjudication.append(val)
                 continue
             }
             self.adjudication[index].populate(from: t)
@@ -1284,7 +1348,11 @@ open class ClaimResponseItemDetail: BackboneElement {
 
         for (index, t) in o.subDetail.enumerated() {
             guard index < self.subDetail.count else {
-                self.subDetail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseItemDetailSubDetail()
+                val.populate(from: t)
+                self.subDetail.append(val)
                 continue
             }
             self.subDetail[index].populate(from: t)
@@ -1459,7 +1527,11 @@ open class ClaimResponseItemDetailSubDetail: BackboneElement {
 
         for (index, t) in o.adjudication.enumerated() {
             guard index < self.adjudication.count else {
-                self.adjudication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClaimResponseItemDetailSubDetailAdjudication()
+                val.populate(from: t)
+                self.adjudication.append(val)
                 continue
             }
             self.adjudication[index].populate(from: t)

--- a/firekit/firekit/classes/models/ClinicalImpression.swift
+++ b/firekit/firekit/classes/models/ClinicalImpression.swift
@@ -2,10 +2,10 @@
 //  ClinicalImpression.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClinicalImpression) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ClinicalImpression) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -170,7 +170,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.action.enumerated() {
             guard index < self.action.count else {
-                self.action.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.action.append(val)
                 continue
             }
             self.action[index].populate(from: t)
@@ -187,7 +191,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.finding.enumerated() {
             guard index < self.finding.count else {
-                self.finding.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClinicalImpressionFinding()
+                val.populate(from: t)
+                self.finding.append(val)
                 continue
             }
             self.finding[index].populate(from: t)
@@ -201,7 +209,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.investigations.enumerated() {
             guard index < self.investigations.count else {
-                self.investigations.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClinicalImpressionInvestigations()
+                val.populate(from: t)
+                self.investigations.append(val)
                 continue
             }
             self.investigations[index].populate(from: t)
@@ -216,7 +228,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.plan.enumerated() {
             guard index < self.plan.count else {
-                self.plan.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.plan.append(val)
                 continue
             }
             self.plan[index].populate(from: t)
@@ -231,7 +247,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.problem.enumerated() {
             guard index < self.problem.count else {
-                self.problem.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.problem.append(val)
                 continue
             }
             self.problem[index].populate(from: t)
@@ -247,7 +267,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.resolved.enumerated() {
             guard index < self.resolved.count else {
-                self.resolved.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.resolved.append(val)
                 continue
             }
             self.resolved[index].populate(from: t)
@@ -261,7 +285,11 @@ open class ClinicalImpression: DomainResource {
 
         for (index, t) in o.ruledOut.enumerated() {
             guard index < self.ruledOut.count else {
-                self.ruledOut.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ClinicalImpressionRuledOut()
+                val.populate(from: t)
+                self.ruledOut.append(val)
                 continue
             }
             self.ruledOut[index].populate(from: t)
@@ -438,7 +466,11 @@ open class ClinicalImpressionInvestigations: BackboneElement {
 
         for (index, t) in o.item.enumerated() {
             guard index < self.item.count else {
-                self.item.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.item.append(val)
                 continue
             }
             self.item[index].populate(from: t)

--- a/firekit/firekit/classes/models/CodeableConcept.swift
+++ b/firekit/firekit/classes/models/CodeableConcept.swift
@@ -2,10 +2,10 @@
 //  CodeableConcept.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CodeableConcept) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CodeableConcept) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -80,7 +80,11 @@ open class CodeableConcept: Element {
 
         for (index, t) in o.coding.enumerated() {
             guard index < self.coding.count else {
-                self.coding.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.coding.append(val)
                 continue
             }
             self.coding[index].populate(from: t)

--- a/firekit/firekit/classes/models/Coding.swift
+++ b/firekit/firekit/classes/models/Coding.swift
@@ -2,10 +2,10 @@
 //  Coding.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coding) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coding) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Communication.swift
+++ b/firekit/firekit/classes/models/Communication.swift
@@ -2,10 +2,10 @@
 //  Communication.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Communication) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Communication) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -142,7 +142,11 @@ open class Communication: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -156,7 +160,11 @@ open class Communication: DomainResource {
 
         for (index, t) in o.medium.enumerated() {
             guard index < self.medium.count else {
-                self.medium.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.medium.append(val)
                 continue
             }
             self.medium[index].populate(from: t)
@@ -170,7 +178,11 @@ open class Communication: DomainResource {
 
         for (index, t) in o.payload.enumerated() {
             guard index < self.payload.count else {
-                self.payload.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CommunicationPayload()
+                val.populate(from: t)
+                self.payload.append(val)
                 continue
             }
             self.payload[index].populate(from: t)
@@ -184,7 +196,11 @@ open class Communication: DomainResource {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -199,7 +215,11 @@ open class Communication: DomainResource {
 
         for (index, t) in o.recipient.enumerated() {
             guard index < self.recipient.count else {
-                self.recipient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.recipient.append(val)
                 continue
             }
             self.recipient[index].populate(from: t)

--- a/firekit/firekit/classes/models/CommunicationRequest.swift
+++ b/firekit/firekit/classes/models/CommunicationRequest.swift
@@ -2,10 +2,10 @@
 //  CommunicationRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CommunicationRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/CommunicationRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -156,7 +156,11 @@ open class CommunicationRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -170,7 +174,11 @@ open class CommunicationRequest: DomainResource {
 
         for (index, t) in o.medium.enumerated() {
             guard index < self.medium.count else {
-                self.medium.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.medium.append(val)
                 continue
             }
             self.medium[index].populate(from: t)
@@ -184,7 +192,11 @@ open class CommunicationRequest: DomainResource {
 
         for (index, t) in o.payload.enumerated() {
             guard index < self.payload.count else {
-                self.payload.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CommunicationRequestPayload()
+                val.populate(from: t)
+                self.payload.append(val)
                 continue
             }
             self.payload[index].populate(from: t)
@@ -199,7 +211,11 @@ open class CommunicationRequest: DomainResource {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -213,7 +229,11 @@ open class CommunicationRequest: DomainResource {
 
         for (index, t) in o.recipient.enumerated() {
             guard index < self.recipient.count else {
-                self.recipient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.recipient.append(val)
                 continue
             }
             self.recipient[index].populate(from: t)

--- a/firekit/firekit/classes/models/Composition.swift
+++ b/firekit/firekit/classes/models/Composition.swift
@@ -2,10 +2,10 @@
 //  Composition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Composition) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Composition) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -161,7 +161,11 @@ open class Composition: DomainResource {
 
         for (index, t) in o.attester.enumerated() {
             guard index < self.attester.count else {
-                self.attester.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CompositionAttester()
+                val.populate(from: t)
+                self.attester.append(val)
                 continue
             }
             self.attester[index].populate(from: t)
@@ -175,7 +179,11 @@ open class Composition: DomainResource {
 
         for (index, t) in o.author.enumerated() {
             guard index < self.author.count else {
-                self.author.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.author.append(val)
                 continue
             }
             self.author[index].populate(from: t)
@@ -194,7 +202,11 @@ open class Composition: DomainResource {
 
         for (index, t) in o.event.enumerated() {
             guard index < self.event.count else {
-                self.event.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CompositionEvent()
+                val.populate(from: t)
+                self.event.append(val)
                 continue
             }
             self.event[index].populate(from: t)
@@ -209,7 +221,11 @@ open class Composition: DomainResource {
 
         for (index, t) in o.section.enumerated() {
             guard index < self.section.count else {
-                self.section.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CompositionSection()
+                val.populate(from: t)
+                self.section.append(val)
                 continue
             }
             self.section[index].populate(from: t)
@@ -308,7 +324,11 @@ open class CompositionAttester: BackboneElement {
 
         for (index, t) in o.mode.enumerated() {
             guard index < self.mode.count else {
-                self.mode.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.mode.append(val)
                 continue
             }
             self.mode[index].populate(from: t)
@@ -399,7 +419,11 @@ open class CompositionEvent: BackboneElement {
 
         for (index, t) in o.code.enumerated() {
             guard index < self.code.count else {
-                self.code.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.code.append(val)
                 continue
             }
             self.code[index].populate(from: t)
@@ -413,7 +437,11 @@ open class CompositionEvent: BackboneElement {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -534,7 +562,11 @@ open class CompositionSection: BackboneElement {
 
         for (index, t) in o.entry.enumerated() {
             guard index < self.entry.count else {
-                self.entry.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.entry.append(val)
                 continue
             }
             self.entry[index].populate(from: t)
@@ -550,7 +582,11 @@ open class CompositionSection: BackboneElement {
 
         for (index, t) in o.section.enumerated() {
             guard index < self.section.count else {
-                self.section.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CompositionSection()
+                val.populate(from: t)
+                self.section.append(val)
                 continue
             }
             self.section[index].populate(from: t)

--- a/firekit/firekit/classes/models/ConceptMap.swift
+++ b/firekit/firekit/classes/models/ConceptMap.swift
@@ -2,10 +2,10 @@
 //  ConceptMap.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ConceptMap) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ConceptMap) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -164,7 +164,11 @@ open class ConceptMap: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConceptMapContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -181,7 +185,11 @@ open class ConceptMap: DomainResource {
 
         for (index, t) in o.element.enumerated() {
             guard index < self.element.count else {
-                self.element.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConceptMapElement()
+                val.populate(from: t)
+                self.element.append(val)
                 continue
             }
             self.element[index].populate(from: t)
@@ -206,7 +214,11 @@ open class ConceptMap: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -290,7 +302,11 @@ open class ConceptMapContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -378,7 +394,11 @@ open class ConceptMapElement: BackboneElement {
 
         for (index, t) in o.target.enumerated() {
             guard index < self.target.count else {
-                self.target.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConceptMapElementTarget()
+                val.populate(from: t)
+                self.target.append(val)
                 continue
             }
             self.target[index].populate(from: t)
@@ -485,7 +505,11 @@ open class ConceptMapElementTarget: BackboneElement {
 
         for (index, t) in o.dependsOn.enumerated() {
             guard index < self.dependsOn.count else {
-                self.dependsOn.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConceptMapElementTargetDependsOn()
+                val.populate(from: t)
+                self.dependsOn.append(val)
                 continue
             }
             self.dependsOn[index].populate(from: t)
@@ -500,7 +524,11 @@ open class ConceptMapElementTarget: BackboneElement {
 
         for (index, t) in o.product.enumerated() {
             guard index < self.product.count else {
-                self.product.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConceptMapElementTargetDependsOn()
+                val.populate(from: t)
+                self.product.append(val)
                 continue
             }
             self.product[index].populate(from: t)

--- a/firekit/firekit/classes/models/Condition.swift
+++ b/firekit/firekit/classes/models/Condition.swift
@@ -2,10 +2,10 @@
 //  Condition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Condition) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Condition) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -228,7 +228,11 @@ open class Condition: DomainResource {
 
         for (index, t) in o.bodySite.enumerated() {
             guard index < self.bodySite.count else {
-                self.bodySite.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.bodySite.append(val)
                 continue
             }
             self.bodySite[index].populate(from: t)
@@ -247,7 +251,11 @@ open class Condition: DomainResource {
 
         for (index, t) in o.evidence.enumerated() {
             guard index < self.evidence.count else {
-                self.evidence.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConditionEvidence()
+                val.populate(from: t)
+                self.evidence.append(val)
                 continue
             }
             self.evidence[index].populate(from: t)
@@ -261,7 +269,11 @@ open class Condition: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -357,7 +369,11 @@ open class ConditionEvidence: BackboneElement {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -442,7 +458,11 @@ open class ConditionStage: BackboneElement {
 
         for (index, t) in o.assessment.enumerated() {
             guard index < self.assessment.count else {
-                self.assessment.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.assessment.append(val)
                 continue
             }
             self.assessment[index].populate(from: t)

--- a/firekit/firekit/classes/models/Conformance.swift
+++ b/firekit/firekit/classes/models/Conformance.swift
@@ -2,10 +2,10 @@
 //  Conformance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Conformance) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Conformance) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -174,7 +174,11 @@ open class Conformance: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -191,7 +195,11 @@ open class Conformance: DomainResource {
 
         for (index, t) in o.document.enumerated() {
             guard index < self.document.count else {
-                self.document.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceDocument()
+                val.populate(from: t)
+                self.document.append(val)
                 continue
             }
             self.document[index].populate(from: t)
@@ -207,7 +215,11 @@ open class Conformance: DomainResource {
 
         for (index, t) in o.format.enumerated() {
             guard index < self.format.count else {
-                self.format.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.format.append(val)
                 continue
             }
             self.format[index].populate(from: t)
@@ -223,7 +235,11 @@ open class Conformance: DomainResource {
 
         for (index, t) in o.messaging.enumerated() {
             guard index < self.messaging.count else {
-                self.messaging.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceMessaging()
+                val.populate(from: t)
+                self.messaging.append(val)
                 continue
             }
             self.messaging[index].populate(from: t)
@@ -238,7 +254,11 @@ open class Conformance: DomainResource {
 
         for (index, t) in o.profile.enumerated() {
             guard index < self.profile.count else {
-                self.profile.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.profile.append(val)
                 continue
             }
             self.profile[index].populate(from: t)
@@ -254,7 +274,11 @@ open class Conformance: DomainResource {
 
         for (index, t) in o.rest.enumerated() {
             guard index < self.rest.count else {
-                self.rest.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRest()
+                val.populate(from: t)
+                self.rest.append(val)
                 continue
             }
             self.rest[index].populate(from: t)
@@ -341,7 +365,11 @@ open class ConformanceContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -600,7 +628,11 @@ open class ConformanceMessaging: BackboneElement {
 
         for (index, t) in o.endpoint.enumerated() {
             guard index < self.endpoint.count else {
-                self.endpoint.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceMessagingEndpoint()
+                val.populate(from: t)
+                self.endpoint.append(val)
                 continue
             }
             self.endpoint[index].populate(from: t)
@@ -614,7 +646,11 @@ open class ConformanceMessaging: BackboneElement {
 
         for (index, t) in o.event.enumerated() {
             guard index < self.event.count else {
-                self.event.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceMessagingEvent()
+                val.populate(from: t)
+                self.event.append(val)
                 continue
             }
             self.event[index].populate(from: t)
@@ -929,7 +965,11 @@ open class ConformanceRest: BackboneElement {
 
         for (index, t) in o.compartment.enumerated() {
             guard index < self.compartment.count else {
-                self.compartment.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.compartment.append(val)
                 continue
             }
             self.compartment[index].populate(from: t)
@@ -944,7 +984,11 @@ open class ConformanceRest: BackboneElement {
 
         for (index, t) in o.interaction.enumerated() {
             guard index < self.interaction.count else {
-                self.interaction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestInteraction()
+                val.populate(from: t)
+                self.interaction.append(val)
                 continue
             }
             self.interaction[index].populate(from: t)
@@ -959,7 +1003,11 @@ open class ConformanceRest: BackboneElement {
 
         for (index, t) in o.operation.enumerated() {
             guard index < self.operation.count else {
-                self.operation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestOperation()
+                val.populate(from: t)
+                self.operation.append(val)
                 continue
             }
             self.operation[index].populate(from: t)
@@ -973,7 +1021,11 @@ open class ConformanceRest: BackboneElement {
 
         for (index, t) in o.resource.enumerated() {
             guard index < self.resource.count else {
-                self.resource.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestResource()
+                val.populate(from: t)
+                self.resource.append(val)
                 continue
             }
             self.resource[index].populate(from: t)
@@ -987,7 +1039,11 @@ open class ConformanceRest: BackboneElement {
 
         for (index, t) in o.searchParam.enumerated() {
             guard index < self.searchParam.count else {
-                self.searchParam.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestResourceSearchParam()
+                val.populate(from: t)
+                self.searchParam.append(val)
                 continue
             }
             self.searchParam[index].populate(from: t)
@@ -1280,7 +1336,11 @@ open class ConformanceRestResource: BackboneElement {
 
         for (index, t) in o.interaction.enumerated() {
             guard index < self.interaction.count else {
-                self.interaction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestResourceInteraction()
+                val.populate(from: t)
+                self.interaction.append(val)
                 continue
             }
             self.interaction[index].populate(from: t)
@@ -1296,7 +1356,11 @@ open class ConformanceRestResource: BackboneElement {
 
         for (index, t) in o.searchInclude.enumerated() {
             guard index < self.searchInclude.count else {
-                self.searchInclude.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.searchInclude.append(val)
                 continue
             }
             self.searchInclude[index].populate(from: t)
@@ -1310,7 +1374,11 @@ open class ConformanceRestResource: BackboneElement {
 
         for (index, t) in o.searchParam.enumerated() {
             guard index < self.searchParam.count else {
-                self.searchParam.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestResourceSearchParam()
+                val.populate(from: t)
+                self.searchParam.append(val)
                 continue
             }
             self.searchParam[index].populate(from: t)
@@ -1324,7 +1392,11 @@ open class ConformanceRestResource: BackboneElement {
 
         for (index, t) in o.searchRevInclude.enumerated() {
             guard index < self.searchRevInclude.count else {
-                self.searchRevInclude.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.searchRevInclude.append(val)
                 continue
             }
             self.searchRevInclude[index].populate(from: t)
@@ -1513,7 +1585,11 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 
         for (index, t) in o.chain.enumerated() {
             guard index < self.chain.count else {
-                self.chain.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.chain.append(val)
                 continue
             }
             self.chain[index].populate(from: t)
@@ -1529,7 +1605,11 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 
         for (index, t) in o.modifier.enumerated() {
             guard index < self.modifier.count else {
-                self.modifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.modifier.append(val)
                 continue
             }
             self.modifier[index].populate(from: t)
@@ -1544,7 +1624,11 @@ open class ConformanceRestResourceSearchParam: BackboneElement {
 
         for (index, t) in o.target.enumerated() {
             guard index < self.target.count else {
-                self.target.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.target.append(val)
                 continue
             }
             self.target[index].populate(from: t)
@@ -1635,7 +1719,11 @@ open class ConformanceRestSecurity: BackboneElement {
 
         for (index, t) in o.certificate.enumerated() {
             guard index < self.certificate.count else {
-                self.certificate.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ConformanceRestSecurityCertificate()
+                val.populate(from: t)
+                self.certificate.append(val)
                 continue
             }
             self.certificate[index].populate(from: t)
@@ -1651,7 +1739,11 @@ open class ConformanceRestSecurity: BackboneElement {
 
         for (index, t) in o.service.enumerated() {
             guard index < self.service.count else {
-                self.service.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.service.append(val)
                 continue
             }
             self.service[index].populate(from: t)

--- a/firekit/firekit/classes/models/ContactPoint.swift
+++ b/firekit/firekit/classes/models/ContactPoint.swift
@@ -2,10 +2,10 @@
 //  ContactPoint.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ContactPoint) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ContactPoint) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Contract.swift
+++ b/firekit/firekit/classes/models/Contract.swift
@@ -2,10 +2,10 @@
 //  Contract.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Contract) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Contract) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -163,7 +163,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.action.enumerated() {
             guard index < self.action.count else {
-                self.action.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.action.append(val)
                 continue
             }
             self.action[index].populate(from: t)
@@ -177,7 +181,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.actionReason.enumerated() {
             guard index < self.actionReason.count else {
-                self.actionReason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.actionReason.append(val)
                 continue
             }
             self.actionReason[index].populate(from: t)
@@ -191,7 +199,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.actor.enumerated() {
             guard index < self.actor.count else {
-                self.actor.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractActor()
+                val.populate(from: t)
+                self.actor.append(val)
                 continue
             }
             self.actor[index].populate(from: t)
@@ -206,7 +218,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.authority.enumerated() {
             guard index < self.authority.count else {
-                self.authority.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.authority.append(val)
                 continue
             }
             self.authority[index].populate(from: t)
@@ -222,7 +238,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.domain.enumerated() {
             guard index < self.domain.count else {
-                self.domain.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.domain.append(val)
                 continue
             }
             self.domain[index].populate(from: t)
@@ -236,7 +256,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.friendly.enumerated() {
             guard index < self.friendly.count else {
-                self.friendly.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractFriendly()
+                val.populate(from: t)
+                self.friendly.append(val)
                 continue
             }
             self.friendly[index].populate(from: t)
@@ -252,7 +276,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.legal.enumerated() {
             guard index < self.legal.count else {
-                self.legal.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractLegal()
+                val.populate(from: t)
+                self.legal.append(val)
                 continue
             }
             self.legal[index].populate(from: t)
@@ -266,7 +294,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.rule.enumerated() {
             guard index < self.rule.count else {
-                self.rule.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractRule()
+                val.populate(from: t)
+                self.rule.append(val)
                 continue
             }
             self.rule[index].populate(from: t)
@@ -280,7 +312,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.signer.enumerated() {
             guard index < self.signer.count else {
-                self.signer.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractSigner()
+                val.populate(from: t)
+                self.signer.append(val)
                 continue
             }
             self.signer[index].populate(from: t)
@@ -294,7 +330,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.subType.enumerated() {
             guard index < self.subType.count else {
-                self.subType.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.subType.append(val)
                 continue
             }
             self.subType[index].populate(from: t)
@@ -308,7 +348,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.subject.enumerated() {
             guard index < self.subject.count else {
-                self.subject.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.subject.append(val)
                 continue
             }
             self.subject[index].populate(from: t)
@@ -322,7 +366,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.term.enumerated() {
             guard index < self.term.count else {
-                self.term.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractTerm()
+                val.populate(from: t)
+                self.term.append(val)
                 continue
             }
             self.term[index].populate(from: t)
@@ -337,7 +385,11 @@ open class Contract: DomainResource {
 
         for (index, t) in o.valuedItem.enumerated() {
             guard index < self.valuedItem.count else {
-                self.valuedItem.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractValuedItem()
+                val.populate(from: t)
+                self.valuedItem.append(val)
                 continue
             }
             self.valuedItem[index].populate(from: t)
@@ -429,7 +481,11 @@ open class ContractActor: BackboneElement {
 
         for (index, t) in o.role.enumerated() {
             guard index < self.role.count else {
-                self.role.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.role.append(val)
                 continue
             }
             self.role[index].populate(from: t)
@@ -907,7 +963,11 @@ open class ContractTerm: BackboneElement {
 
         for (index, t) in o.action.enumerated() {
             guard index < self.action.count else {
-                self.action.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.action.append(val)
                 continue
             }
             self.action[index].populate(from: t)
@@ -921,7 +981,11 @@ open class ContractTerm: BackboneElement {
 
         for (index, t) in o.actionReason.enumerated() {
             guard index < self.actionReason.count else {
-                self.actionReason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.actionReason.append(val)
                 continue
             }
             self.actionReason[index].populate(from: t)
@@ -935,7 +999,11 @@ open class ContractTerm: BackboneElement {
 
         for (index, t) in o.actor.enumerated() {
             guard index < self.actor.count else {
-                self.actor.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractTermActor()
+                val.populate(from: t)
+                self.actor.append(val)
                 continue
             }
             self.actor[index].populate(from: t)
@@ -950,7 +1018,11 @@ open class ContractTerm: BackboneElement {
 
         for (index, t) in o.group.enumerated() {
             guard index < self.group.count else {
-                self.group.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractTerm()
+                val.populate(from: t)
+                self.group.append(val)
                 continue
             }
             self.group[index].populate(from: t)
@@ -970,7 +1042,11 @@ open class ContractTerm: BackboneElement {
 
         for (index, t) in o.valuedItem.enumerated() {
             guard index < self.valuedItem.count else {
-                self.valuedItem.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContractTermValuedItem()
+                val.populate(from: t)
+                self.valuedItem.append(val)
                 continue
             }
             self.valuedItem[index].populate(from: t)
@@ -1062,7 +1138,11 @@ open class ContractTermActor: BackboneElement {
 
         for (index, t) in o.role.enumerated() {
             guard index < self.role.count else {
-                self.role.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.role.append(val)
                 continue
             }
             self.role[index].populate(from: t)

--- a/firekit/firekit/classes/models/Count.swift
+++ b/firekit/firekit/classes/models/Count.swift
@@ -2,10 +2,10 @@
 //  Count.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Count) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Count) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Coverage.swift
+++ b/firekit/firekit/classes/models/Coverage.swift
@@ -2,10 +2,10 @@
 //  Coverage.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coverage) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Coverage) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -150,7 +150,11 @@ open class Coverage: DomainResource {
 
         for (index, t) in o.contract.enumerated() {
             guard index < self.contract.count else {
-                self.contract.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.contract.append(val)
                 continue
             }
             self.contract[index].populate(from: t)
@@ -166,7 +170,11 @@ open class Coverage: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/DataElement.swift
+++ b/firekit/firekit/classes/models/DataElement.swift
@@ -2,10 +2,10 @@
 //  DataElement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DataElement) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DataElement) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -135,7 +135,11 @@ open class DataElement: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DataElementContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -151,7 +155,11 @@ open class DataElement: DomainResource {
 
         for (index, t) in o.element.enumerated() {
             guard index < self.element.count else {
-                self.element.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ElementDefinition()
+                val.populate(from: t)
+                self.element.append(val)
                 continue
             }
             self.element[index].populate(from: t)
@@ -166,7 +174,11 @@ open class DataElement: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -180,7 +192,11 @@ open class DataElement: DomainResource {
 
         for (index, t) in o.mapping.enumerated() {
             guard index < self.mapping.count else {
-                self.mapping.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DataElementMapping()
+                val.populate(from: t)
+                self.mapping.append(val)
                 continue
             }
             self.mapping[index].populate(from: t)
@@ -199,7 +215,11 @@ open class DataElement: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -283,7 +303,11 @@ open class DataElementContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/DetectedIssue.swift
+++ b/firekit/firekit/classes/models/DetectedIssue.swift
@@ -2,10 +2,10 @@
 //  DetectedIssue.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DetectedIssue) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DetectedIssue) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -130,7 +130,11 @@ open class DetectedIssue: DomainResource {
 
         for (index, t) in o.implicated.enumerated() {
             guard index < self.implicated.count else {
-                self.implicated.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.implicated.append(val)
                 continue
             }
             self.implicated[index].populate(from: t)
@@ -144,7 +148,11 @@ open class DetectedIssue: DomainResource {
 
         for (index, t) in o.mitigation.enumerated() {
             guard index < self.mitigation.count else {
-                self.mitigation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DetectedIssueMitigation()
+                val.populate(from: t)
+                self.mitigation.append(val)
                 continue
             }
             self.mitigation[index].populate(from: t)

--- a/firekit/firekit/classes/models/Device.swift
+++ b/firekit/firekit/classes/models/Device.swift
@@ -2,10 +2,10 @@
 //  Device.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Device) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Device) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -158,7 +158,11 @@ open class Device: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -173,7 +177,11 @@ open class Device: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -192,7 +200,11 @@ open class Device: DomainResource {
 
         for (index, t) in o.note.enumerated() {
             guard index < self.note.count else {
-                self.note.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.note.append(val)
                 continue
             }
             self.note[index].populate(from: t)

--- a/firekit/firekit/classes/models/DeviceComponent.swift
+++ b/firekit/firekit/classes/models/DeviceComponent.swift
@@ -2,10 +2,10 @@
 //  DeviceComponent.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceComponent) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceComponent) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -143,7 +143,11 @@ open class DeviceComponent: DomainResource {
 
         for (index, t) in o.operationalStatus.enumerated() {
             guard index < self.operationalStatus.count else {
-                self.operationalStatus.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.operationalStatus.append(val)
                 continue
             }
             self.operationalStatus[index].populate(from: t)
@@ -159,7 +163,11 @@ open class DeviceComponent: DomainResource {
 
         for (index, t) in o.productionSpecification.enumerated() {
             guard index < self.productionSpecification.count else {
-                self.productionSpecification.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DeviceComponentProductionSpecification()
+                val.populate(from: t)
+                self.productionSpecification.append(val)
                 continue
             }
             self.productionSpecification[index].populate(from: t)

--- a/firekit/firekit/classes/models/DeviceMetric.swift
+++ b/firekit/firekit/classes/models/DeviceMetric.swift
@@ -2,10 +2,10 @@
 //  DeviceMetric.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceMetric) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceMetric) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -138,7 +138,11 @@ open class DeviceMetric: DomainResource {
 
         for (index, t) in o.calibration.enumerated() {
             guard index < self.calibration.count else {
-                self.calibration.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DeviceMetricCalibration()
+                val.populate(from: t)
+                self.calibration.append(val)
                 continue
             }
             self.calibration[index].populate(from: t)

--- a/firekit/firekit/classes/models/DeviceUseRequest.swift
+++ b/firekit/firekit/classes/models/DeviceUseRequest.swift
@@ -2,10 +2,10 @@
 //  DeviceUseRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -169,7 +169,11 @@ open class DeviceUseRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -183,7 +187,11 @@ open class DeviceUseRequest: DomainResource {
 
         for (index, t) in o.indication.enumerated() {
             guard index < self.indication.count else {
-                self.indication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.indication.append(val)
                 continue
             }
             self.indication[index].populate(from: t)
@@ -197,7 +205,11 @@ open class DeviceUseRequest: DomainResource {
 
         for (index, t) in o.notes.enumerated() {
             guard index < self.notes.count else {
-                self.notes.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.notes.append(val)
                 continue
             }
             self.notes[index].populate(from: t)
@@ -213,7 +225,11 @@ open class DeviceUseRequest: DomainResource {
 
         for (index, t) in o.prnReason.enumerated() {
             guard index < self.prnReason.count else {
-                self.prnReason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.prnReason.append(val)
                 continue
             }
             self.prnReason[index].populate(from: t)

--- a/firekit/firekit/classes/models/DeviceUseStatement.swift
+++ b/firekit/firekit/classes/models/DeviceUseStatement.swift
@@ -2,10 +2,10 @@
 //  DeviceUseStatement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseStatement) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DeviceUseStatement) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -152,7 +152,11 @@ open class DeviceUseStatement: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -166,7 +170,11 @@ open class DeviceUseStatement: DomainResource {
 
         for (index, t) in o.indication.enumerated() {
             guard index < self.indication.count else {
-                self.indication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.indication.append(val)
                 continue
             }
             self.indication[index].populate(from: t)
@@ -180,7 +188,11 @@ open class DeviceUseStatement: DomainResource {
 
         for (index, t) in o.notes.enumerated() {
             guard index < self.notes.count else {
-                self.notes.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.notes.append(val)
                 continue
             }
             self.notes[index].populate(from: t)

--- a/firekit/firekit/classes/models/DiagnosticOrder.swift
+++ b/firekit/firekit/classes/models/DiagnosticOrder.swift
@@ -2,10 +2,10 @@
 //  DiagnosticOrder.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticOrder) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticOrder) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -136,7 +136,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.event.enumerated() {
             guard index < self.event.count else {
-                self.event.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DiagnosticOrderEvent()
+                val.populate(from: t)
+                self.event.append(val)
                 continue
             }
             self.event[index].populate(from: t)
@@ -150,7 +154,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -164,7 +172,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.item.enumerated() {
             guard index < self.item.count else {
-                self.item.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DiagnosticOrderItem()
+                val.populate(from: t)
+                self.item.append(val)
                 continue
             }
             self.item[index].populate(from: t)
@@ -178,7 +190,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.note.enumerated() {
             guard index < self.note.count else {
-                self.note.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.note.append(val)
                 continue
             }
             self.note[index].populate(from: t)
@@ -194,7 +210,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -208,7 +228,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.specimen.enumerated() {
             guard index < self.specimen.count else {
-                self.specimen.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.specimen.append(val)
                 continue
             }
             self.specimen[index].populate(from: t)
@@ -224,7 +248,11 @@ open class DiagnosticOrder: DomainResource {
 
         for (index, t) in o.supportingInformation.enumerated() {
             guard index < self.supportingInformation.count else {
-                self.supportingInformation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.supportingInformation.append(val)
                 continue
             }
             self.supportingInformation[index].populate(from: t)
@@ -427,7 +455,11 @@ open class DiagnosticOrderItem: BackboneElement {
 
         for (index, t) in o.event.enumerated() {
             guard index < self.event.count else {
-                self.event.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DiagnosticOrderEvent()
+                val.populate(from: t)
+                self.event.append(val)
                 continue
             }
             self.event[index].populate(from: t)
@@ -441,7 +473,11 @@ open class DiagnosticOrderItem: BackboneElement {
 
         for (index, t) in o.specimen.enumerated() {
             guard index < self.specimen.count else {
-                self.specimen.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.specimen.append(val)
                 continue
             }
             self.specimen[index].populate(from: t)

--- a/firekit/firekit/classes/models/DiagnosticReport.swift
+++ b/firekit/firekit/classes/models/DiagnosticReport.swift
@@ -2,10 +2,10 @@
 //  DiagnosticReport.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticReport) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DiagnosticReport) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -180,7 +180,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.codedDiagnosis.enumerated() {
             guard index < self.codedDiagnosis.count else {
-                self.codedDiagnosis.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.codedDiagnosis.append(val)
                 continue
             }
             self.codedDiagnosis[index].populate(from: t)
@@ -198,7 +202,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -212,7 +220,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.image.enumerated() {
             guard index < self.image.count else {
-                self.image.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DiagnosticReportImage()
+                val.populate(from: t)
+                self.image.append(val)
                 continue
             }
             self.image[index].populate(from: t)
@@ -226,7 +238,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.imagingStudy.enumerated() {
             guard index < self.imagingStudy.count else {
-                self.imagingStudy.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.imagingStudy.append(val)
                 continue
             }
             self.imagingStudy[index].populate(from: t)
@@ -242,7 +258,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.presentedForm.enumerated() {
             guard index < self.presentedForm.count else {
-                self.presentedForm.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Attachment()
+                val.populate(from: t)
+                self.presentedForm.append(val)
                 continue
             }
             self.presentedForm[index].populate(from: t)
@@ -256,7 +276,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.request.enumerated() {
             guard index < self.request.count else {
-                self.request.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.request.append(val)
                 continue
             }
             self.request[index].populate(from: t)
@@ -270,7 +294,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.result.enumerated() {
             guard index < self.result.count else {
-                self.result.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.result.append(val)
                 continue
             }
             self.result[index].populate(from: t)
@@ -284,7 +312,11 @@ open class DiagnosticReport: DomainResource {
 
         for (index, t) in o.specimen.enumerated() {
             guard index < self.specimen.count else {
-                self.specimen.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.specimen.append(val)
                 continue
             }
             self.specimen[index].populate(from: t)

--- a/firekit/firekit/classes/models/Distance.swift
+++ b/firekit/firekit/classes/models/Distance.swift
@@ -2,10 +2,10 @@
 //  Distance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Distance) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Distance) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/DocumentManifest.swift
+++ b/firekit/firekit/classes/models/DocumentManifest.swift
@@ -2,10 +2,10 @@
 //  DocumentManifest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentManifest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentManifest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -134,7 +134,11 @@ open class DocumentManifest: DomainResource {
 
         for (index, t) in o.author.enumerated() {
             guard index < self.author.count else {
-                self.author.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.author.append(val)
                 continue
             }
             self.author[index].populate(from: t)
@@ -148,7 +152,11 @@ open class DocumentManifest: DomainResource {
 
         for (index, t) in o.content.enumerated() {
             guard index < self.content.count else {
-                self.content.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DocumentManifestContent()
+                val.populate(from: t)
+                self.content.append(val)
                 continue
             }
             self.content[index].populate(from: t)
@@ -164,7 +172,11 @@ open class DocumentManifest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -179,7 +191,11 @@ open class DocumentManifest: DomainResource {
 
         for (index, t) in o.recipient.enumerated() {
             guard index < self.recipient.count else {
-                self.recipient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.recipient.append(val)
                 continue
             }
             self.recipient[index].populate(from: t)
@@ -193,7 +209,11 @@ open class DocumentManifest: DomainResource {
 
         for (index, t) in o.related.enumerated() {
             guard index < self.related.count else {
-                self.related.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DocumentManifestRelated()
+                val.populate(from: t)
+                self.related.append(val)
                 continue
             }
             self.related[index].populate(from: t)

--- a/firekit/firekit/classes/models/DocumentReference.swift
+++ b/firekit/firekit/classes/models/DocumentReference.swift
@@ -2,10 +2,10 @@
 //  DocumentReference.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentReference) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DocumentReference) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -174,7 +174,11 @@ open class DocumentReference: DomainResource {
 
         for (index, t) in o.author.enumerated() {
             guard index < self.author.count else {
-                self.author.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.author.append(val)
                 continue
             }
             self.author[index].populate(from: t)
@@ -189,7 +193,11 @@ open class DocumentReference: DomainResource {
 
         for (index, t) in o.content.enumerated() {
             guard index < self.content.count else {
-                self.content.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DocumentReferenceContent()
+                val.populate(from: t)
+                self.content.append(val)
                 continue
             }
             self.content[index].populate(from: t)
@@ -208,7 +216,11 @@ open class DocumentReference: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -224,7 +236,11 @@ open class DocumentReference: DomainResource {
 
         for (index, t) in o.relatesTo.enumerated() {
             guard index < self.relatesTo.count else {
-                self.relatesTo.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DocumentReferenceRelatesTo()
+                val.populate(from: t)
+                self.relatesTo.append(val)
                 continue
             }
             self.relatesTo[index].populate(from: t)
@@ -238,7 +254,11 @@ open class DocumentReference: DomainResource {
 
         for (index, t) in o.securityLabel.enumerated() {
             guard index < self.securityLabel.count else {
-                self.securityLabel.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.securityLabel.append(val)
                 continue
             }
             self.securityLabel[index].populate(from: t)
@@ -333,7 +353,11 @@ open class DocumentReferenceContent: BackboneElement {
 
         for (index, t) in o.format.enumerated() {
             guard index < self.format.count else {
-                self.format.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.format.append(val)
                 continue
             }
             self.format[index].populate(from: t)
@@ -451,7 +475,11 @@ open class DocumentReferenceContext: BackboneElement {
 
         for (index, t) in o.event.enumerated() {
             guard index < self.event.count else {
-                self.event.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.event.append(val)
                 continue
             }
             self.event[index].populate(from: t)
@@ -468,7 +496,11 @@ open class DocumentReferenceContext: BackboneElement {
 
         for (index, t) in o.related.enumerated() {
             guard index < self.related.count else {
-                self.related.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DocumentReferenceContextRelated()
+                val.populate(from: t)
+                self.related.append(val)
                 continue
             }
             self.related[index].populate(from: t)

--- a/firekit/firekit/classes/models/DomainResource.swift
+++ b/firekit/firekit/classes/models/DomainResource.swift
@@ -2,10 +2,10 @@
 //  DomainResource.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DomainResource) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/DomainResource) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -114,7 +114,11 @@ open class DomainResource: Resource {
 
         for (index, t) in o.contained.enumerated() {
             guard index < self.contained.count else {
-                self.contained.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContainedResource()
+                val.populate(from: t)
+                self.contained.append(val)
                 continue
             }
             self.contained[index].populate(from: t)
@@ -128,7 +132,11 @@ open class DomainResource: Resource {
 
         for (index, t) in o.extension_fhir.enumerated() {
             guard index < self.extension_fhir.count else {
-                self.extension_fhir.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Extension()
+                val.populate(from: t)
+                self.extension_fhir.append(val)
                 continue
             }
             self.extension_fhir[index].populate(from: t)
@@ -142,7 +150,11 @@ open class DomainResource: Resource {
 
         for (index, t) in o.modifierExtension.enumerated() {
             guard index < self.modifierExtension.count else {
-                self.modifierExtension.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Extension()
+                val.populate(from: t)
+                self.modifierExtension.append(val)
                 continue
             }
             self.modifierExtension[index].populate(from: t)

--- a/firekit/firekit/classes/models/Duration.swift
+++ b/firekit/firekit/classes/models/Duration.swift
@@ -2,10 +2,10 @@
 //  Duration.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Duration) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Duration) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Element.swift
+++ b/firekit/firekit/classes/models/Element.swift
@@ -2,10 +2,10 @@
 //  Element.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Element) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Element) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -82,7 +82,11 @@ open class Element: FHIRAbstractBase {
 
         for (index, t) in o.extension_fhir.enumerated() {
             guard index < self.extension_fhir.count else {
-                self.extension_fhir.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Extension()
+                val.populate(from: t)
+                self.extension_fhir.append(val)
                 continue
             }
             self.extension_fhir[index].populate(from: t)

--- a/firekit/firekit/classes/models/ElementDefinition.swift
+++ b/firekit/firekit/classes/models/ElementDefinition.swift
@@ -2,10 +2,10 @@
 //  ElementDefinition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ElementDefinition) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ElementDefinition) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -1285,7 +1285,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.alias.enumerated() {
             guard index < self.alias.count else {
-                self.alias.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.alias.append(val)
                 continue
             }
             self.alias[index].populate(from: t)
@@ -1301,7 +1305,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.code.enumerated() {
             guard index < self.code.count else {
-                self.code.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.code.append(val)
                 continue
             }
             self.code[index].populate(from: t)
@@ -1316,7 +1324,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.condition.enumerated() {
             guard index < self.condition.count else {
-                self.condition.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.condition.append(val)
                 continue
             }
             self.condition[index].populate(from: t)
@@ -1330,7 +1342,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.constraint.enumerated() {
             guard index < self.constraint.count else {
-                self.constraint.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ElementDefinitionConstraint()
+                val.populate(from: t)
+                self.constraint.append(val)
                 continue
             }
             self.constraint[index].populate(from: t)
@@ -1447,7 +1463,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.mapping.enumerated() {
             guard index < self.mapping.count else {
-                self.mapping.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ElementDefinitionMapping()
+                val.populate(from: t)
+                self.mapping.append(val)
                 continue
             }
             self.mapping[index].populate(from: t)
@@ -1568,7 +1588,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.representation.enumerated() {
             guard index < self.representation.count else {
-                self.representation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.representation.append(val)
                 continue
             }
             self.representation[index].populate(from: t)
@@ -1585,7 +1609,11 @@ open class ElementDefinition: Element {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ElementDefinitionType()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)
@@ -2038,7 +2066,11 @@ open class ElementDefinitionSlicing: Element {
 
         for (index, t) in o.discriminator.enumerated() {
             guard index < self.discriminator.count else {
-                self.discriminator.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.discriminator.append(val)
                 continue
             }
             self.discriminator[index].populate(from: t)
@@ -2132,7 +2164,11 @@ open class ElementDefinitionType: Element {
 
         for (index, t) in o.aggregation.enumerated() {
             guard index < self.aggregation.count else {
-                self.aggregation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.aggregation.append(val)
                 continue
             }
             self.aggregation[index].populate(from: t)
@@ -2147,7 +2183,11 @@ open class ElementDefinitionType: Element {
 
         for (index, t) in o.profile.enumerated() {
             guard index < self.profile.count else {
-                self.profile.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.profile.append(val)
                 continue
             }
             self.profile[index].populate(from: t)

--- a/firekit/firekit/classes/models/EligibilityRequest.swift
+++ b/firekit/firekit/classes/models/EligibilityRequest.swift
@@ -2,10 +2,10 @@
 //  EligibilityRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -117,7 +117,11 @@ open class EligibilityRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/EligibilityResponse.swift
+++ b/firekit/firekit/classes/models/EligibilityResponse.swift
@@ -2,10 +2,10 @@
 //  EligibilityResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EligibilityResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -132,7 +132,11 @@ open class EligibilityResponse: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Encounter.swift
+++ b/firekit/firekit/classes/models/Encounter.swift
@@ -2,10 +2,10 @@
 //  Encounter.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Encounter) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Encounter) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -181,7 +181,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.episodeOfCare.enumerated() {
             guard index < self.episodeOfCare.count else {
-                self.episodeOfCare.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.episodeOfCare.append(val)
                 continue
             }
             self.episodeOfCare[index].populate(from: t)
@@ -196,7 +200,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -210,7 +218,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.incomingReferral.enumerated() {
             guard index < self.incomingReferral.count else {
-                self.incomingReferral.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.incomingReferral.append(val)
                 continue
             }
             self.incomingReferral[index].populate(from: t)
@@ -224,7 +236,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.indication.enumerated() {
             guard index < self.indication.count else {
-                self.indication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.indication.append(val)
                 continue
             }
             self.indication[index].populate(from: t)
@@ -239,7 +255,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.location.enumerated() {
             guard index < self.location.count else {
-                self.location.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = EncounterLocation()
+                val.populate(from: t)
+                self.location.append(val)
                 continue
             }
             self.location[index].populate(from: t)
@@ -254,7 +274,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.participant.enumerated() {
             guard index < self.participant.count else {
-                self.participant.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = EncounterParticipant()
+                val.populate(from: t)
+                self.participant.append(val)
                 continue
             }
             self.participant[index].populate(from: t)
@@ -271,7 +295,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -287,7 +315,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.statusHistory.enumerated() {
             guard index < self.statusHistory.count else {
-                self.statusHistory.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = EncounterStatusHistory()
+                val.populate(from: t)
+                self.statusHistory.append(val)
                 continue
             }
             self.statusHistory[index].populate(from: t)
@@ -301,7 +333,11 @@ open class Encounter: DomainResource {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)
@@ -436,7 +472,11 @@ open class EncounterHospitalization: BackboneElement {
 
         for (index, t) in o.admittingDiagnosis.enumerated() {
             guard index < self.admittingDiagnosis.count else {
-                self.admittingDiagnosis.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.admittingDiagnosis.append(val)
                 continue
             }
             self.admittingDiagnosis[index].populate(from: t)
@@ -451,7 +491,11 @@ open class EncounterHospitalization: BackboneElement {
 
         for (index, t) in o.dietPreference.enumerated() {
             guard index < self.dietPreference.count else {
-                self.dietPreference.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.dietPreference.append(val)
                 continue
             }
             self.dietPreference[index].populate(from: t)
@@ -465,7 +509,11 @@ open class EncounterHospitalization: BackboneElement {
 
         for (index, t) in o.dischargeDiagnosis.enumerated() {
             guard index < self.dischargeDiagnosis.count else {
-                self.dischargeDiagnosis.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.dischargeDiagnosis.append(val)
                 continue
             }
             self.dischargeDiagnosis[index].populate(from: t)
@@ -483,7 +531,11 @@ open class EncounterHospitalization: BackboneElement {
 
         for (index, t) in o.specialArrangement.enumerated() {
             guard index < self.specialArrangement.count else {
-                self.specialArrangement.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.specialArrangement.append(val)
                 continue
             }
             self.specialArrangement[index].populate(from: t)
@@ -497,7 +549,11 @@ open class EncounterHospitalization: BackboneElement {
 
         for (index, t) in o.specialCourtesy.enumerated() {
             guard index < self.specialCourtesy.count else {
-                self.specialCourtesy.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.specialCourtesy.append(val)
                 continue
             }
             self.specialCourtesy[index].populate(from: t)
@@ -678,7 +734,11 @@ open class EncounterParticipant: BackboneElement {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)

--- a/firekit/firekit/classes/models/EnrollmentRequest.swift
+++ b/firekit/firekit/classes/models/EnrollmentRequest.swift
@@ -2,10 +2,10 @@
 //  EnrollmentRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -146,7 +146,11 @@ open class EnrollmentRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/EnrollmentResponse.swift
+++ b/firekit/firekit/classes/models/EnrollmentResponse.swift
@@ -2,10 +2,10 @@
 //  EnrollmentResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EnrollmentResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -132,7 +132,11 @@ open class EnrollmentResponse: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/EpisodeOfCare.swift
+++ b/firekit/firekit/classes/models/EpisodeOfCare.swift
@@ -2,10 +2,10 @@
 //  EpisodeOfCare.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EpisodeOfCare) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/EpisodeOfCare) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -138,7 +138,11 @@ open class EpisodeOfCare: DomainResource {
 
         for (index, t) in o.careTeam.enumerated() {
             guard index < self.careTeam.count else {
-                self.careTeam.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = EpisodeOfCareCareTeam()
+                val.populate(from: t)
+                self.careTeam.append(val)
                 continue
             }
             self.careTeam[index].populate(from: t)
@@ -152,7 +156,11 @@ open class EpisodeOfCare: DomainResource {
 
         for (index, t) in o.condition.enumerated() {
             guard index < self.condition.count else {
-                self.condition.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.condition.append(val)
                 continue
             }
             self.condition[index].populate(from: t)
@@ -166,7 +174,11 @@ open class EpisodeOfCare: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -183,7 +195,11 @@ open class EpisodeOfCare: DomainResource {
 
         for (index, t) in o.referralRequest.enumerated() {
             guard index < self.referralRequest.count else {
-                self.referralRequest.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.referralRequest.append(val)
                 continue
             }
             self.referralRequest[index].populate(from: t)
@@ -198,7 +214,11 @@ open class EpisodeOfCare: DomainResource {
 
         for (index, t) in o.statusHistory.enumerated() {
             guard index < self.statusHistory.count else {
-                self.statusHistory.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = EpisodeOfCareStatusHistory()
+                val.populate(from: t)
+                self.statusHistory.append(val)
                 continue
             }
             self.statusHistory[index].populate(from: t)
@@ -212,7 +232,11 @@ open class EpisodeOfCare: DomainResource {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)
@@ -306,7 +330,11 @@ open class EpisodeOfCareCareTeam: BackboneElement {
 
         for (index, t) in o.role.enumerated() {
             guard index < self.role.count else {
-                self.role.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.role.append(val)
                 continue
             }
             self.role[index].populate(from: t)

--- a/firekit/firekit/classes/models/ExplanationOfBenefit.swift
+++ b/firekit/firekit/classes/models/ExplanationOfBenefit.swift
@@ -2,10 +2,10 @@
 //  ExplanationOfBenefit.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -133,7 +133,11 @@ open class ExplanationOfBenefit: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Extension.swift
+++ b/firekit/firekit/classes/models/Extension.swift
@@ -2,10 +2,10 @@
 //  Extension.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Extension) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Extension) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/FHIRAbstractBase.swift
+++ b/firekit/firekit/classes/models/FHIRAbstractBase.swift
@@ -43,46 +43,30 @@ open class FHIRAbstractBase: Object, Codable, NSCopying, Populatable {
 
     // MARK: - Realm Element convenience method
     func upsert<T: Element>(prop: inout T?, val: T?) {
-        if prop != nil && val != nil {
-            prop!.populate(from: val! as Any)
-            return
-        }
-        
-        if prop != nil && val == nil {
-            guard let r = realm else {
-                prop?.cascadeDelete()
-                prop = nil
-                return
-            }
-            
-            r.delete(prop!)
+        guard let value = val else {
+            prop?.cascadeDelete()
             prop = nil
             return
         }
-
-        prop = val
+        
+        if prop == nil {
+            prop = T.init()
+        }
+        prop?.populate(from: value as Any)
     }
 
     // ugh, this is so lame.
     func upsert<T: Resource>(prop: inout T?, val: T?) {
-        if prop != nil && val != nil {
-            prop!.populate(from: val! as Any)
-            return
-        }
-        
-        if prop != nil && val == nil {
-            guard let r = realm else {
-                prop?.cascadeDelete()
-                prop = nil
-                return
-            }
-            
-            r.delete(prop!)
+        guard let value = val else {
+            prop?.cascadeDelete()
             prop = nil
             return
         }
         
-        prop = val
+        if prop == nil {
+            prop = T.init()
+        }
+        prop?.populate(from: value as Any)
     }
 
     public func copy(with zone: NSZone? = nil) -> Any {

--- a/firekit/firekit/classes/models/Factories.swift
+++ b/firekit/firekit/classes/models/Factories.swift
@@ -2,10 +2,10 @@
 //  FHIRAbstractBase+Factory.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 //
 import Foundation

--- a/firekit/firekit/classes/models/FamilyMemberHistory.swift
+++ b/firekit/firekit/classes/models/FamilyMemberHistory.swift
@@ -2,10 +2,10 @@
 //  FamilyMemberHistory.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -191,7 +191,11 @@ open class FamilyMemberHistory: DomainResource {
 
         for (index, t) in o.condition.enumerated() {
             guard index < self.condition.count else {
-                self.condition.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = FamilyMemberHistoryCondition()
+                val.populate(from: t)
+                self.condition.append(val)
                 continue
             }
             self.condition[index].populate(from: t)
@@ -212,7 +216,11 @@ open class FamilyMemberHistory: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Flag.swift
+++ b/firekit/firekit/classes/models/Flag.swift
@@ -2,10 +2,10 @@
 //  Flag.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Flag) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Flag) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -134,7 +134,11 @@ open class Flag: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Goal.swift
+++ b/firekit/firekit/classes/models/Goal.swift
@@ -2,10 +2,10 @@
 //  Goal.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Goal) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Goal) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -162,7 +162,11 @@ open class Goal: DomainResource {
 
         for (index, t) in o.addresses.enumerated() {
             guard index < self.addresses.count else {
-                self.addresses.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.addresses.append(val)
                 continue
             }
             self.addresses[index].populate(from: t)
@@ -177,7 +181,11 @@ open class Goal: DomainResource {
 
         for (index, t) in o.category.enumerated() {
             guard index < self.category.count else {
-                self.category.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.category.append(val)
                 continue
             }
             self.category[index].populate(from: t)
@@ -192,7 +200,11 @@ open class Goal: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -206,7 +218,11 @@ open class Goal: DomainResource {
 
         for (index, t) in o.note.enumerated() {
             guard index < self.note.count else {
-                self.note.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.note.append(val)
                 continue
             }
             self.note[index].populate(from: t)
@@ -220,7 +236,11 @@ open class Goal: DomainResource {
 
         for (index, t) in o.outcome.enumerated() {
             guard index < self.outcome.count else {
-                self.outcome.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = GoalOutcome()
+                val.populate(from: t)
+                self.outcome.append(val)
                 continue
             }
             self.outcome[index].populate(from: t)

--- a/firekit/firekit/classes/models/Group.swift
+++ b/firekit/firekit/classes/models/Group.swift
@@ -2,10 +2,10 @@
 //  Group.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Group) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Group) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -117,7 +117,11 @@ open class Group: DomainResource {
 
         for (index, t) in o.characteristic.enumerated() {
             guard index < self.characteristic.count else {
-                self.characteristic.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = GroupCharacteristic()
+                val.populate(from: t)
+                self.characteristic.append(val)
                 continue
             }
             self.characteristic[index].populate(from: t)
@@ -132,7 +136,11 @@ open class Group: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -146,7 +154,11 @@ open class Group: DomainResource {
 
         for (index, t) in o.member.enumerated() {
             guard index < self.member.count else {
-                self.member.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = GroupMember()
+                val.populate(from: t)
+                self.member.append(val)
                 continue
             }
             self.member[index].populate(from: t)

--- a/firekit/firekit/classes/models/HealthcareService.swift
+++ b/firekit/firekit/classes/models/HealthcareService.swift
@@ -2,10 +2,10 @@
 //  HealthcareService.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HealthcareService) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HealthcareService) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -181,7 +181,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.availableTime.enumerated() {
             guard index < self.availableTime.count else {
-                self.availableTime.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = HealthcareServiceAvailableTime()
+                val.populate(from: t)
+                self.availableTime.append(val)
                 continue
             }
             self.availableTime[index].populate(from: t)
@@ -195,7 +199,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.characteristic.enumerated() {
             guard index < self.characteristic.count else {
-                self.characteristic.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.characteristic.append(val)
                 continue
             }
             self.characteristic[index].populate(from: t)
@@ -210,7 +218,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.coverageArea.enumerated() {
             guard index < self.coverageArea.count else {
-                self.coverageArea.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.coverageArea.append(val)
                 continue
             }
             self.coverageArea[index].populate(from: t)
@@ -227,7 +239,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -242,7 +258,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.notAvailable.enumerated() {
             guard index < self.notAvailable.count else {
-                self.notAvailable.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = HealthcareServiceNotAvailable()
+                val.populate(from: t)
+                self.notAvailable.append(val)
                 continue
             }
             self.notAvailable[index].populate(from: t)
@@ -257,7 +277,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.programName.enumerated() {
             guard index < self.programName.count else {
-                self.programName.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.programName.append(val)
                 continue
             }
             self.programName[index].populate(from: t)
@@ -273,7 +297,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.referralMethod.enumerated() {
             guard index < self.referralMethod.count else {
-                self.referralMethod.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.referralMethod.append(val)
                 continue
             }
             self.referralMethod[index].populate(from: t)
@@ -289,7 +317,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.serviceProvisionCode.enumerated() {
             guard index < self.serviceProvisionCode.count else {
-                self.serviceProvisionCode.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.serviceProvisionCode.append(val)
                 continue
             }
             self.serviceProvisionCode[index].populate(from: t)
@@ -303,7 +335,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.serviceType.enumerated() {
             guard index < self.serviceType.count else {
-                self.serviceType.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = HealthcareServiceServiceType()
+                val.populate(from: t)
+                self.serviceType.append(val)
                 continue
             }
             self.serviceType[index].populate(from: t)
@@ -317,7 +353,11 @@ open class HealthcareService: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -410,7 +450,11 @@ open class HealthcareServiceAvailableTime: BackboneElement {
 
         for (index, t) in o.daysOfWeek.enumerated() {
             guard index < self.daysOfWeek.count else {
-                self.daysOfWeek.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.daysOfWeek.append(val)
                 continue
             }
             self.daysOfWeek[index].populate(from: t)
@@ -580,7 +624,11 @@ open class HealthcareServiceServiceType: BackboneElement {
 
         for (index, t) in o.specialty.enumerated() {
             guard index < self.specialty.count else {
-                self.specialty.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.specialty.append(val)
                 continue
             }
             self.specialty[index].populate(from: t)

--- a/firekit/firekit/classes/models/HumanName.swift
+++ b/firekit/firekit/classes/models/HumanName.swift
@@ -2,10 +2,10 @@
 //  HumanName.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HumanName) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/HumanName) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -103,7 +103,11 @@ open class HumanName: Element {
 
         for (index, t) in o.family.enumerated() {
             guard index < self.family.count else {
-                self.family.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.family.append(val)
                 continue
             }
             self.family[index].populate(from: t)
@@ -117,7 +121,11 @@ open class HumanName: Element {
 
         for (index, t) in o.given.enumerated() {
             guard index < self.given.count else {
-                self.given.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.given.append(val)
                 continue
             }
             self.given[index].populate(from: t)
@@ -132,7 +140,11 @@ open class HumanName: Element {
 
         for (index, t) in o.prefix.enumerated() {
             guard index < self.prefix.count else {
-                self.prefix.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.prefix.append(val)
                 continue
             }
             self.prefix[index].populate(from: t)
@@ -146,7 +158,11 @@ open class HumanName: Element {
 
         for (index, t) in o.suffix.enumerated() {
             guard index < self.suffix.count else {
-                self.suffix.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.suffix.append(val)
                 continue
             }
             self.suffix[index].populate(from: t)

--- a/firekit/firekit/classes/models/Identifier.swift
+++ b/firekit/firekit/classes/models/Identifier.swift
@@ -2,10 +2,10 @@
 //  Identifier.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Identifier) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Identifier) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/ImagingObjectSelection.swift
+++ b/firekit/firekit/classes/models/ImagingObjectSelection.swift
@@ -2,10 +2,10 @@
 //  ImagingObjectSelection.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingObjectSelection) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingObjectSelection) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -128,7 +128,11 @@ open class ImagingObjectSelection: DomainResource {
 
         for (index, t) in o.study.enumerated() {
             guard index < self.study.count else {
-                self.study.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImagingObjectSelectionStudy()
+                val.populate(from: t)
+                self.study.append(val)
                 continue
             }
             self.study[index].populate(from: t)
@@ -231,7 +235,11 @@ open class ImagingObjectSelectionStudy: BackboneElement {
 
         for (index, t) in o.series.enumerated() {
             guard index < self.series.count else {
-                self.series.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImagingObjectSelectionStudySeries()
+                val.populate(from: t)
+                self.series.append(val)
                 continue
             }
             self.series[index].populate(from: t)
@@ -325,7 +333,11 @@ open class ImagingObjectSelectionStudySeries: BackboneElement {
 
         for (index, t) in o.instance.enumerated() {
             guard index < self.instance.count else {
-                self.instance.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImagingObjectSelectionStudySeriesInstance()
+                val.populate(from: t)
+                self.instance.append(val)
                 continue
             }
             self.instance[index].populate(from: t)
@@ -425,7 +437,11 @@ open class ImagingObjectSelectionStudySeriesInstance: BackboneElement {
 
         for (index, t) in o.frames.enumerated() {
             guard index < self.frames.count else {
-                self.frames.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImagingObjectSelectionStudySeriesInstanceFrames()
+                val.populate(from: t)
+                self.frames.append(val)
                 continue
             }
             self.frames[index].populate(from: t)
@@ -517,7 +533,11 @@ open class ImagingObjectSelectionStudySeriesInstanceFrames: BackboneElement {
 
         for (index, t) in o.frameNumbers.enumerated() {
             guard index < self.frameNumbers.count else {
-                self.frameNumbers.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmInt()
+                val.populate(from: t)
+                self.frameNumbers.append(val)
                 continue
             }
             self.frameNumbers[index].populate(from: t)

--- a/firekit/firekit/classes/models/ImagingStudy.swift
+++ b/firekit/firekit/classes/models/ImagingStudy.swift
@@ -2,10 +2,10 @@
 //  ImagingStudy.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingStudy) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImagingStudy) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -163,7 +163,11 @@ open class ImagingStudy: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -178,7 +182,11 @@ open class ImagingStudy: DomainResource {
 
         for (index, t) in o.modalityList.enumerated() {
             guard index < self.modalityList.count else {
-                self.modalityList.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.modalityList.append(val)
                 continue
             }
             self.modalityList[index].populate(from: t)
@@ -194,7 +202,11 @@ open class ImagingStudy: DomainResource {
 
         for (index, t) in o.order.enumerated() {
             guard index < self.order.count else {
-                self.order.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.order.append(val)
                 continue
             }
             self.order[index].populate(from: t)
@@ -209,7 +221,11 @@ open class ImagingStudy: DomainResource {
 
         for (index, t) in o.procedure.enumerated() {
             guard index < self.procedure.count else {
-                self.procedure.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.procedure.append(val)
                 continue
             }
             self.procedure[index].populate(from: t)
@@ -224,7 +240,11 @@ open class ImagingStudy: DomainResource {
 
         for (index, t) in o.series.enumerated() {
             guard index < self.series.count else {
-                self.series.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImagingStudySeries()
+                val.populate(from: t)
+                self.series.append(val)
                 continue
             }
             self.series[index].populate(from: t)
@@ -365,7 +385,11 @@ open class ImagingStudySeries: BackboneElement {
 
         for (index, t) in o.instance.enumerated() {
             guard index < self.instance.count else {
-                self.instance.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImagingStudySeriesInstance()
+                val.populate(from: t)
+                self.instance.append(val)
                 continue
             }
             self.instance[index].populate(from: t)
@@ -477,7 +501,11 @@ open class ImagingStudySeriesInstance: BackboneElement {
 
         for (index, t) in o.content.enumerated() {
             guard index < self.content.count else {
-                self.content.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Attachment()
+                val.populate(from: t)
+                self.content.append(val)
                 continue
             }
             self.content[index].populate(from: t)

--- a/firekit/firekit/classes/models/Immunization.swift
+++ b/firekit/firekit/classes/models/Immunization.swift
@@ -2,10 +2,10 @@
 //  Immunization.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Immunization) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Immunization) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -206,7 +206,11 @@ open class Immunization: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -223,7 +227,11 @@ open class Immunization: DomainResource {
 
         for (index, t) in o.note.enumerated() {
             guard index < self.note.count else {
-                self.note.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.note.append(val)
                 continue
             }
             self.note[index].populate(from: t)
@@ -239,7 +247,11 @@ open class Immunization: DomainResource {
 
         for (index, t) in o.reaction.enumerated() {
             guard index < self.reaction.count else {
-                self.reaction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImmunizationReaction()
+                val.populate(from: t)
+                self.reaction.append(val)
                 continue
             }
             self.reaction[index].populate(from: t)
@@ -258,7 +270,11 @@ open class Immunization: DomainResource {
 
         for (index, t) in o.vaccinationProtocol.enumerated() {
             guard index < self.vaccinationProtocol.count else {
-                self.vaccinationProtocol.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImmunizationVaccinationProtocol()
+                val.populate(from: t)
+                self.vaccinationProtocol.append(val)
                 continue
             }
             self.vaccinationProtocol[index].populate(from: t)
@@ -342,7 +358,11 @@ open class ImmunizationExplanation: BackboneElement {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -356,7 +376,11 @@ open class ImmunizationExplanation: BackboneElement {
 
         for (index, t) in o.reasonNotGiven.enumerated() {
             guard index < self.reasonNotGiven.count else {
-                self.reasonNotGiven.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reasonNotGiven.append(val)
                 continue
             }
             self.reasonNotGiven[index].populate(from: t)
@@ -564,7 +588,11 @@ open class ImmunizationVaccinationProtocol: BackboneElement {
 
         for (index, t) in o.targetDisease.enumerated() {
             guard index < self.targetDisease.count else {
-                self.targetDisease.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.targetDisease.append(val)
                 continue
             }
             self.targetDisease[index].populate(from: t)

--- a/firekit/firekit/classes/models/ImmunizationRecommendation.swift
+++ b/firekit/firekit/classes/models/ImmunizationRecommendation.swift
@@ -2,10 +2,10 @@
 //  ImmunizationRecommendation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -95,7 +95,11 @@ open class ImmunizationRecommendation: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -110,7 +114,11 @@ open class ImmunizationRecommendation: DomainResource {
 
         for (index, t) in o.recommendation.enumerated() {
             guard index < self.recommendation.count else {
-                self.recommendation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImmunizationRecommendationRecommendation()
+                val.populate(from: t)
+                self.recommendation.append(val)
                 continue
             }
             self.recommendation[index].populate(from: t)
@@ -232,7 +240,11 @@ open class ImmunizationRecommendationRecommendation: BackboneElement {
 
         for (index, t) in o.dateCriterion.enumerated() {
             guard index < self.dateCriterion.count else {
-                self.dateCriterion.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImmunizationRecommendationRecommendationDateCriterion()
+                val.populate(from: t)
+                self.dateCriterion.append(val)
                 continue
             }
             self.dateCriterion[index].populate(from: t)
@@ -249,7 +261,11 @@ open class ImmunizationRecommendationRecommendation: BackboneElement {
 
         for (index, t) in o.supportingImmunization.enumerated() {
             guard index < self.supportingImmunization.count else {
-                self.supportingImmunization.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.supportingImmunization.append(val)
                 continue
             }
             self.supportingImmunization[index].populate(from: t)
@@ -263,7 +279,11 @@ open class ImmunizationRecommendationRecommendation: BackboneElement {
 
         for (index, t) in o.supportingPatientInformation.enumerated() {
             guard index < self.supportingPatientInformation.count else {
-                self.supportingPatientInformation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.supportingPatientInformation.append(val)
                 continue
             }
             self.supportingPatientInformation[index].populate(from: t)

--- a/firekit/firekit/classes/models/ImplementationGuide.swift
+++ b/firekit/firekit/classes/models/ImplementationGuide.swift
@@ -2,10 +2,10 @@
 //  ImplementationGuide.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImplementationGuide) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ImplementationGuide) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -154,7 +154,11 @@ open class ImplementationGuide: DomainResource {
 
         for (index, t) in o.binary.enumerated() {
             guard index < self.binary.count else {
-                self.binary.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.binary.append(val)
                 continue
             }
             self.binary[index].populate(from: t)
@@ -168,7 +172,11 @@ open class ImplementationGuide: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImplementationGuideContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -184,7 +192,11 @@ open class ImplementationGuide: DomainResource {
 
         for (index, t) in o.dependency.enumerated() {
             guard index < self.dependency.count else {
-                self.dependency.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImplementationGuideDependency()
+                val.populate(from: t)
+                self.dependency.append(val)
                 continue
             }
             self.dependency[index].populate(from: t)
@@ -201,7 +213,11 @@ open class ImplementationGuide: DomainResource {
 
         for (index, t) in o.global.enumerated() {
             guard index < self.global.count else {
-                self.global.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImplementationGuideGlobal()
+                val.populate(from: t)
+                self.global.append(val)
                 continue
             }
             self.global[index].populate(from: t)
@@ -216,7 +232,11 @@ open class ImplementationGuide: DomainResource {
 
         for (index, t) in o.package.enumerated() {
             guard index < self.package.count else {
-                self.package.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImplementationGuidePackage()
+                val.populate(from: t)
+                self.package.append(val)
                 continue
             }
             self.package[index].populate(from: t)
@@ -234,7 +254,11 @@ open class ImplementationGuide: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -318,7 +342,11 @@ open class ImplementationGuideContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -571,7 +599,11 @@ open class ImplementationGuidePackage: BackboneElement {
 
         for (index, t) in o.resource.enumerated() {
             guard index < self.resource.count else {
-                self.resource.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImplementationGuidePackageResource()
+                val.populate(from: t)
+                self.resource.append(val)
                 continue
             }
             self.resource[index].populate(from: t)
@@ -795,7 +827,11 @@ open class ImplementationGuidePage: BackboneElement {
 
         for (index, t) in o.package.enumerated() {
             guard index < self.package.count else {
-                self.package.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.package.append(val)
                 continue
             }
             self.package[index].populate(from: t)
@@ -809,7 +845,11 @@ open class ImplementationGuidePage: BackboneElement {
 
         for (index, t) in o.page.enumerated() {
             guard index < self.page.count else {
-                self.page.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ImplementationGuidePage()
+                val.populate(from: t)
+                self.page.append(val)
                 continue
             }
             self.page[index].populate(from: t)
@@ -824,7 +864,11 @@ open class ImplementationGuidePage: BackboneElement {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)

--- a/firekit/firekit/classes/models/List.swift
+++ b/firekit/firekit/classes/models/List.swift
@@ -2,10 +2,10 @@
 //  List.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/List) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/List) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -153,7 +153,11 @@ open class List: DomainResource {
 
         for (index, t) in o.entry.enumerated() {
             guard index < self.entry.count else {
-                self.entry.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ListEntry()
+                val.populate(from: t)
+                self.entry.append(val)
                 continue
             }
             self.entry[index].populate(from: t)
@@ -167,7 +171,11 @@ open class List: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Location.swift
+++ b/firekit/firekit/classes/models/Location.swift
@@ -2,10 +2,10 @@
 //  Location.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Location) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Location) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -141,7 +141,11 @@ open class Location: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -162,7 +166,11 @@ open class Location: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/Media.swift
+++ b/firekit/firekit/classes/models/Media.swift
@@ -2,10 +2,10 @@
 //  Media.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Media) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Media) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -146,7 +146,11 @@ open class Media: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Medication.swift
+++ b/firekit/firekit/classes/models/Medication.swift
@@ -2,10 +2,10 @@
 //  Medication.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Medication) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Medication) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -182,7 +182,11 @@ open class MedicationPackage: BackboneElement {
 
         for (index, t) in o.content.enumerated() {
             guard index < self.content.count else {
-                self.content.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MedicationPackageContent()
+                val.populate(from: t)
+                self.content.append(val)
                 continue
             }
             self.content[index].populate(from: t)
@@ -353,7 +357,11 @@ open class MedicationProduct: BackboneElement {
 
         for (index, t) in o.batch.enumerated() {
             guard index < self.batch.count else {
-                self.batch.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MedicationProductBatch()
+                val.populate(from: t)
+                self.batch.append(val)
                 continue
             }
             self.batch[index].populate(from: t)
@@ -368,7 +376,11 @@ open class MedicationProduct: BackboneElement {
 
         for (index, t) in o.ingredient.enumerated() {
             guard index < self.ingredient.count else {
-                self.ingredient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MedicationProductIngredient()
+                val.populate(from: t)
+                self.ingredient.append(val)
                 continue
             }
             self.ingredient[index].populate(from: t)

--- a/firekit/firekit/classes/models/MedicationAdministration.swift
+++ b/firekit/firekit/classes/models/MedicationAdministration.swift
@@ -2,10 +2,10 @@
 //  MedicationAdministration.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationAdministration) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationAdministration) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -173,7 +173,11 @@ open class MedicationAdministration: DomainResource {
 
         for (index, t) in o.device.enumerated() {
             guard index < self.device.count else {
-                self.device.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.device.append(val)
                 continue
             }
             self.device[index].populate(from: t)
@@ -191,7 +195,11 @@ open class MedicationAdministration: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -211,7 +219,11 @@ open class MedicationAdministration: DomainResource {
 
         for (index, t) in o.reasonGiven.enumerated() {
             guard index < self.reasonGiven.count else {
-                self.reasonGiven.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reasonGiven.append(val)
                 continue
             }
             self.reasonGiven[index].populate(from: t)
@@ -225,7 +237,11 @@ open class MedicationAdministration: DomainResource {
 
         for (index, t) in o.reasonNotGiven.enumerated() {
             guard index < self.reasonNotGiven.count else {
-                self.reasonNotGiven.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reasonNotGiven.append(val)
                 continue
             }
             self.reasonNotGiven[index].populate(from: t)

--- a/firekit/firekit/classes/models/MedicationDispense.swift
+++ b/firekit/firekit/classes/models/MedicationDispense.swift
@@ -2,10 +2,10 @@
 //  MedicationDispense.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationDispense) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationDispense) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -179,7 +179,11 @@ open class MedicationDispense: DomainResource {
 
         for (index, t) in o.authorizingPrescription.enumerated() {
             guard index < self.authorizingPrescription.count else {
-                self.authorizingPrescription.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.authorizingPrescription.append(val)
                 continue
             }
             self.authorizingPrescription[index].populate(from: t)
@@ -196,7 +200,11 @@ open class MedicationDispense: DomainResource {
 
         for (index, t) in o.dosageInstruction.enumerated() {
             guard index < self.dosageInstruction.count else {
-                self.dosageInstruction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MedicationDispenseDosageInstruction()
+                val.populate(from: t)
+                self.dosageInstruction.append(val)
                 continue
             }
             self.dosageInstruction[index].populate(from: t)
@@ -216,7 +224,11 @@ open class MedicationDispense: DomainResource {
 
         for (index, t) in o.receiver.enumerated() {
             guard index < self.receiver.count else {
-                self.receiver.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.receiver.append(val)
                 continue
             }
             self.receiver[index].populate(from: t)
@@ -484,7 +496,11 @@ open class MedicationDispenseSubstitution: BackboneElement {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -498,7 +514,11 @@ open class MedicationDispenseSubstitution: BackboneElement {
 
         for (index, t) in o.responsibleParty.enumerated() {
             guard index < self.responsibleParty.count else {
-                self.responsibleParty.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.responsibleParty.append(val)
                 continue
             }
             self.responsibleParty[index].populate(from: t)

--- a/firekit/firekit/classes/models/MedicationOrder.swift
+++ b/firekit/firekit/classes/models/MedicationOrder.swift
@@ -2,10 +2,10 @@
 //  MedicationOrder.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationOrder) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationOrder) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -185,7 +185,11 @@ open class MedicationOrder: DomainResource {
 
         for (index, t) in o.dosageInstruction.enumerated() {
             guard index < self.dosageInstruction.count else {
-                self.dosageInstruction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MedicationOrderDosageInstruction()
+                val.populate(from: t)
+                self.dosageInstruction.append(val)
                 continue
             }
             self.dosageInstruction[index].populate(from: t)
@@ -200,7 +204,11 @@ open class MedicationOrder: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/MedicationStatement.swift
+++ b/firekit/firekit/classes/models/MedicationStatement.swift
@@ -2,10 +2,10 @@
 //  MedicationStatement.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationStatement) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MedicationStatement) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -180,7 +180,11 @@ open class MedicationStatement: DomainResource {
 
         for (index, t) in o.dosage.enumerated() {
             guard index < self.dosage.count else {
-                self.dosage.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MedicationStatementDosage()
+                val.populate(from: t)
+                self.dosage.append(val)
                 continue
             }
             self.dosage[index].populate(from: t)
@@ -196,7 +200,11 @@ open class MedicationStatement: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -217,7 +225,11 @@ open class MedicationStatement: DomainResource {
 
         for (index, t) in o.reasonNotTaken.enumerated() {
             guard index < self.reasonNotTaken.count else {
-                self.reasonNotTaken.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reasonNotTaken.append(val)
                 continue
             }
             self.reasonNotTaken[index].populate(from: t)
@@ -232,7 +244,11 @@ open class MedicationStatement: DomainResource {
 
         for (index, t) in o.supportingInformation.enumerated() {
             guard index < self.supportingInformation.count else {
-                self.supportingInformation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.supportingInformation.append(val)
                 continue
             }
             self.supportingInformation[index].populate(from: t)

--- a/firekit/firekit/classes/models/MessageHeader.swift
+++ b/firekit/firekit/classes/models/MessageHeader.swift
@@ -2,10 +2,10 @@
 //  MessageHeader.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MessageHeader) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/MessageHeader) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -151,7 +151,11 @@ open class MessageHeader: DomainResource {
 
         for (index, t) in o.data.enumerated() {
             guard index < self.data.count else {
-                self.data.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.data.append(val)
                 continue
             }
             self.data[index].populate(from: t)
@@ -165,7 +169,11 @@ open class MessageHeader: DomainResource {
 
         for (index, t) in o.destination.enumerated() {
             guard index < self.destination.count else {
-                self.destination.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = MessageHeaderDestination()
+                val.populate(from: t)
+                self.destination.append(val)
                 continue
             }
             self.destination[index].populate(from: t)

--- a/firekit/firekit/classes/models/Meta.swift
+++ b/firekit/firekit/classes/models/Meta.swift
@@ -2,10 +2,10 @@
 //  Meta.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Meta) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Meta) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -94,7 +94,11 @@ open class Meta: Element {
 
         for (index, t) in o.profile.enumerated() {
             guard index < self.profile.count else {
-                self.profile.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.profile.append(val)
                 continue
             }
             self.profile[index].populate(from: t)
@@ -108,7 +112,11 @@ open class Meta: Element {
 
         for (index, t) in o.security.enumerated() {
             guard index < self.security.count else {
-                self.security.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.security.append(val)
                 continue
             }
             self.security[index].populate(from: t)
@@ -122,7 +130,11 @@ open class Meta: Element {
 
         for (index, t) in o.tag.enumerated() {
             guard index < self.tag.count else {
-                self.tag.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.tag.append(val)
                 continue
             }
             self.tag[index].populate(from: t)

--- a/firekit/firekit/classes/models/Money.swift
+++ b/firekit/firekit/classes/models/Money.swift
@@ -2,10 +2,10 @@
 //  Money.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Money) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Money) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/NamingSystem.swift
+++ b/firekit/firekit/classes/models/NamingSystem.swift
@@ -2,10 +2,10 @@
 //  NamingSystem.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NamingSystem) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NamingSystem) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -141,7 +141,11 @@ open class NamingSystem: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = NamingSystemContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -164,7 +168,11 @@ open class NamingSystem: DomainResource {
 
         for (index, t) in o.uniqueId.enumerated() {
             guard index < self.uniqueId.count else {
-                self.uniqueId.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = NamingSystemUniqueId()
+                val.populate(from: t)
+                self.uniqueId.append(val)
                 continue
             }
             self.uniqueId[index].populate(from: t)
@@ -179,7 +187,11 @@ open class NamingSystem: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -262,7 +274,11 @@ open class NamingSystemContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/Narrative.swift
+++ b/firekit/firekit/classes/models/Narrative.swift
@@ -2,10 +2,10 @@
 //  Narrative.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Narrative) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Narrative) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/NutritionOrder.swift
+++ b/firekit/firekit/classes/models/NutritionOrder.swift
@@ -2,10 +2,10 @@
 //  NutritionOrder.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NutritionOrder) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/NutritionOrder) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -142,7 +142,11 @@ open class NutritionOrder: DomainResource {
 
         for (index, t) in o.allergyIntolerance.enumerated() {
             guard index < self.allergyIntolerance.count else {
-                self.allergyIntolerance.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.allergyIntolerance.append(val)
                 continue
             }
             self.allergyIntolerance[index].populate(from: t)
@@ -159,7 +163,11 @@ open class NutritionOrder: DomainResource {
 
         for (index, t) in o.excludeFoodModifier.enumerated() {
             guard index < self.excludeFoodModifier.count else {
-                self.excludeFoodModifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.excludeFoodModifier.append(val)
                 continue
             }
             self.excludeFoodModifier[index].populate(from: t)
@@ -173,7 +181,11 @@ open class NutritionOrder: DomainResource {
 
         for (index, t) in o.foodPreferenceModifier.enumerated() {
             guard index < self.foodPreferenceModifier.count else {
-                self.foodPreferenceModifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.foodPreferenceModifier.append(val)
                 continue
             }
             self.foodPreferenceModifier[index].populate(from: t)
@@ -187,7 +199,11 @@ open class NutritionOrder: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -205,7 +221,11 @@ open class NutritionOrder: DomainResource {
 
         for (index, t) in o.supplement.enumerated() {
             guard index < self.supplement.count else {
-                self.supplement.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = NutritionOrderSupplement()
+                val.populate(from: t)
+                self.supplement.append(val)
                 continue
             }
             self.supplement[index].populate(from: t)
@@ -333,7 +353,11 @@ open class NutritionOrderEnteralFormula: BackboneElement {
 
         for (index, t) in o.administration.enumerated() {
             guard index < self.administration.count else {
-                self.administration.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = NutritionOrderEnteralFormulaAdministration()
+                val.populate(from: t)
+                self.administration.append(val)
                 continue
             }
             self.administration[index].populate(from: t)
@@ -531,7 +555,11 @@ open class NutritionOrderOralDiet: BackboneElement {
 
         for (index, t) in o.fluidConsistencyType.enumerated() {
             guard index < self.fluidConsistencyType.count else {
-                self.fluidConsistencyType.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.fluidConsistencyType.append(val)
                 continue
             }
             self.fluidConsistencyType[index].populate(from: t)
@@ -546,7 +574,11 @@ open class NutritionOrderOralDiet: BackboneElement {
 
         for (index, t) in o.nutrient.enumerated() {
             guard index < self.nutrient.count else {
-                self.nutrient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = NutritionOrderOralDietNutrient()
+                val.populate(from: t)
+                self.nutrient.append(val)
                 continue
             }
             self.nutrient[index].populate(from: t)
@@ -560,7 +592,11 @@ open class NutritionOrderOralDiet: BackboneElement {
 
         for (index, t) in o.schedule.enumerated() {
             guard index < self.schedule.count else {
-                self.schedule.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Timing()
+                val.populate(from: t)
+                self.schedule.append(val)
                 continue
             }
             self.schedule[index].populate(from: t)
@@ -574,7 +610,11 @@ open class NutritionOrderOralDiet: BackboneElement {
 
         for (index, t) in o.texture.enumerated() {
             guard index < self.texture.count else {
-                self.texture.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = NutritionOrderOralDietTexture()
+                val.populate(from: t)
+                self.texture.append(val)
                 continue
             }
             self.texture[index].populate(from: t)
@@ -588,7 +628,11 @@ open class NutritionOrderOralDiet: BackboneElement {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)
@@ -844,7 +888,11 @@ open class NutritionOrderSupplement: BackboneElement {
 
         for (index, t) in o.schedule.enumerated() {
             guard index < self.schedule.count else {
-                self.schedule.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Timing()
+                val.populate(from: t)
+                self.schedule.append(val)
                 continue
             }
             self.schedule[index].populate(from: t)

--- a/firekit/firekit/classes/models/Observation.swift
+++ b/firekit/firekit/classes/models/Observation.swift
@@ -2,10 +2,10 @@
 //  Observation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Observation) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Observation) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -257,7 +257,11 @@ open class Observation: DomainResource {
 
         for (index, t) in o.component.enumerated() {
             guard index < self.component.count else {
-                self.component.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ObservationComponent()
+                val.populate(from: t)
+                self.component.append(val)
                 continue
             }
             self.component[index].populate(from: t)
@@ -276,7 +280,11 @@ open class Observation: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -293,7 +301,11 @@ open class Observation: DomainResource {
 
         for (index, t) in o.performer.enumerated() {
             guard index < self.performer.count else {
-                self.performer.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.performer.append(val)
                 continue
             }
             self.performer[index].populate(from: t)
@@ -307,7 +319,11 @@ open class Observation: DomainResource {
 
         for (index, t) in o.referenceRange.enumerated() {
             guard index < self.referenceRange.count else {
-                self.referenceRange.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ObservationReferenceRange()
+                val.populate(from: t)
+                self.referenceRange.append(val)
                 continue
             }
             self.referenceRange[index].populate(from: t)
@@ -321,7 +337,11 @@ open class Observation: DomainResource {
 
         for (index, t) in o.related.enumerated() {
             guard index < self.related.count else {
-                self.related.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ObservationRelated()
+                val.populate(from: t)
+                self.related.append(val)
                 continue
             }
             self.related[index].populate(from: t)
@@ -497,7 +517,11 @@ open class ObservationComponent: BackboneElement {
 
         for (index, t) in o.referenceRange.enumerated() {
             guard index < self.referenceRange.count else {
-                self.referenceRange.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ObservationReferenceRange()
+                val.populate(from: t)
+                self.referenceRange.append(val)
                 continue
             }
             self.referenceRange[index].populate(from: t)

--- a/firekit/firekit/classes/models/OperationDefinition.swift
+++ b/firekit/firekit/classes/models/OperationDefinition.swift
@@ -2,10 +2,10 @@
 //  OperationDefinition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationDefinition) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationDefinition) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -165,7 +165,11 @@ open class OperationDefinition: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = OperationDefinitionContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -187,7 +191,11 @@ open class OperationDefinition: DomainResource {
 
         for (index, t) in o.parameter.enumerated() {
             guard index < self.parameter.count else {
-                self.parameter.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = OperationDefinitionParameter()
+                val.populate(from: t)
+                self.parameter.append(val)
                 continue
             }
             self.parameter[index].populate(from: t)
@@ -205,7 +213,11 @@ open class OperationDefinition: DomainResource {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)
@@ -290,7 +302,11 @@ open class OperationDefinitionContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -420,7 +436,11 @@ open class OperationDefinitionParameter: BackboneElement {
 
         for (index, t) in o.part.enumerated() {
             guard index < self.part.count else {
-                self.part.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = OperationDefinitionParameter()
+                val.populate(from: t)
+                self.part.append(val)
                 continue
             }
             self.part[index].populate(from: t)

--- a/firekit/firekit/classes/models/OperationOutcome.swift
+++ b/firekit/firekit/classes/models/OperationOutcome.swift
@@ -2,10 +2,10 @@
 //  OperationOutcome.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationOutcome) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OperationOutcome) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -82,7 +82,11 @@ open class OperationOutcome: DomainResource {
 
         for (index, t) in o.issue.enumerated() {
             guard index < self.issue.count else {
-                self.issue.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = OperationOutcomeIssue()
+                val.populate(from: t)
+                self.issue.append(val)
                 continue
             }
             self.issue[index].populate(from: t)
@@ -189,7 +193,11 @@ open class OperationOutcomeIssue: BackboneElement {
 
         for (index, t) in o.location.enumerated() {
             guard index < self.location.count else {
-                self.location.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.location.append(val)
                 continue
             }
             self.location[index].populate(from: t)

--- a/firekit/firekit/classes/models/Order.swift
+++ b/firekit/firekit/classes/models/Order.swift
@@ -2,10 +2,10 @@
 //  Order.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Order) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Order) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -131,7 +131,11 @@ open class Order: DomainResource {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -145,7 +149,11 @@ open class Order: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/OrderResponse.swift
+++ b/firekit/firekit/classes/models/OrderResponse.swift
@@ -2,10 +2,10 @@
 //  OrderResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OrderResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/OrderResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -113,7 +113,11 @@ open class OrderResponse: DomainResource {
 
         for (index, t) in o.fulfillment.enumerated() {
             guard index < self.fulfillment.count else {
-                self.fulfillment.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.fulfillment.append(val)
                 continue
             }
             self.fulfillment[index].populate(from: t)
@@ -127,7 +131,11 @@ open class OrderResponse: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Organization.swift
+++ b/firekit/firekit/classes/models/Organization.swift
@@ -2,10 +2,10 @@
 //  Organization.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Organization) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Organization) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -113,7 +113,11 @@ open class Organization: DomainResource {
 
         for (index, t) in o.address.enumerated() {
             guard index < self.address.count else {
-                self.address.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Address()
+                val.populate(from: t)
+                self.address.append(val)
                 continue
             }
             self.address[index].populate(from: t)
@@ -127,7 +131,11 @@ open class Organization: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = OrganizationContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -141,7 +149,11 @@ open class Organization: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -157,7 +169,11 @@ open class Organization: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -258,7 +274,11 @@ open class OrganizationContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/Parameters.swift
+++ b/firekit/firekit/classes/models/Parameters.swift
@@ -2,10 +2,10 @@
 //  Parameters.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Parameters) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Parameters) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -77,7 +77,11 @@ open class Parameters: Resource {
 
         for (index, t) in o.parameter.enumerated() {
             guard index < self.parameter.count else {
-                self.parameter.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ParametersParameter()
+                val.populate(from: t)
+                self.parameter.append(val)
                 continue
             }
             self.parameter[index].populate(from: t)
@@ -360,7 +364,11 @@ open class ParametersParameter: BackboneElement {
 
         for (index, t) in o.part.enumerated() {
             guard index < self.part.count else {
-                self.part.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ParametersParameter()
+                val.populate(from: t)
+                self.part.append(val)
                 continue
             }
             self.part[index].populate(from: t)

--- a/firekit/firekit/classes/models/Patient.swift
+++ b/firekit/firekit/classes/models/Patient.swift
@@ -2,10 +2,10 @@
 //  Patient.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Patient) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Patient) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -159,7 +159,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.address.enumerated() {
             guard index < self.address.count else {
-                self.address.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Address()
+                val.populate(from: t)
+                self.address.append(val)
                 continue
             }
             self.address[index].populate(from: t)
@@ -175,7 +179,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.careProvider.enumerated() {
             guard index < self.careProvider.count else {
-                self.careProvider.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.careProvider.append(val)
                 continue
             }
             self.careProvider[index].populate(from: t)
@@ -189,7 +197,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.communication.enumerated() {
             guard index < self.communication.count else {
-                self.communication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PatientCommunication()
+                val.populate(from: t)
+                self.communication.append(val)
                 continue
             }
             self.communication[index].populate(from: t)
@@ -203,7 +215,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PatientContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -220,7 +236,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -234,7 +254,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.link.enumerated() {
             guard index < self.link.count else {
-                self.link.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PatientLink()
+                val.populate(from: t)
+                self.link.append(val)
                 continue
             }
             self.link[index].populate(from: t)
@@ -252,7 +276,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.name.enumerated() {
             guard index < self.name.count else {
-                self.name.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = HumanName()
+                val.populate(from: t)
+                self.name.append(val)
                 continue
             }
             self.name[index].populate(from: t)
@@ -266,7 +294,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.photo.enumerated() {
             guard index < self.photo.count else {
-                self.photo.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Attachment()
+                val.populate(from: t)
+                self.photo.append(val)
                 continue
             }
             self.photo[index].populate(from: t)
@@ -280,7 +312,11 @@ open class Patient: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -566,7 +602,11 @@ open class PatientContact: BackboneElement {
 
         for (index, t) in o.relationship.enumerated() {
             guard index < self.relationship.count else {
-                self.relationship.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.relationship.append(val)
                 continue
             }
             self.relationship[index].populate(from: t)
@@ -580,7 +620,11 @@ open class PatientContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/PaymentNotice.swift
+++ b/firekit/firekit/classes/models/PaymentNotice.swift
@@ -2,10 +2,10 @@
 //  PaymentNotice.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentNotice) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentNotice) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -144,7 +144,11 @@ open class PaymentNotice: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/PaymentReconciliation.swift
+++ b/firekit/firekit/classes/models/PaymentReconciliation.swift
@@ -2,10 +2,10 @@
 //  PaymentReconciliation.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentReconciliation) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/PaymentReconciliation) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -166,7 +166,11 @@ open class PaymentReconciliation: DomainResource {
 
         for (index, t) in o.detail.enumerated() {
             guard index < self.detail.count else {
-                self.detail.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PaymentReconciliationDetail()
+                val.populate(from: t)
+                self.detail.append(val)
                 continue
             }
             self.detail[index].populate(from: t)
@@ -182,7 +186,11 @@ open class PaymentReconciliation: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -196,7 +204,11 @@ open class PaymentReconciliation: DomainResource {
 
         for (index, t) in o.note.enumerated() {
             guard index < self.note.count else {
-                self.note.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PaymentReconciliationNote()
+                val.populate(from: t)
+                self.note.append(val)
                 continue
             }
             self.note[index].populate(from: t)

--- a/firekit/firekit/classes/models/Period.swift
+++ b/firekit/firekit/classes/models/Period.swift
@@ -2,10 +2,10 @@
 //  Period.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Period) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Period) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Person.swift
+++ b/firekit/firekit/classes/models/Person.swift
@@ -2,10 +2,10 @@
 //  Person.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Person) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Person) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -119,7 +119,11 @@ open class Person: DomainResource {
 
         for (index, t) in o.address.enumerated() {
             guard index < self.address.count else {
-                self.address.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Address()
+                val.populate(from: t)
+                self.address.append(val)
                 continue
             }
             self.address[index].populate(from: t)
@@ -135,7 +139,11 @@ open class Person: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -149,7 +157,11 @@ open class Person: DomainResource {
 
         for (index, t) in o.link.enumerated() {
             guard index < self.link.count else {
-                self.link.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PersonLink()
+                val.populate(from: t)
+                self.link.append(val)
                 continue
             }
             self.link[index].populate(from: t)
@@ -164,7 +176,11 @@ open class Person: DomainResource {
 
         for (index, t) in o.name.enumerated() {
             guard index < self.name.count else {
-                self.name.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = HumanName()
+                val.populate(from: t)
+                self.name.append(val)
                 continue
             }
             self.name[index].populate(from: t)
@@ -179,7 +195,11 @@ open class Person: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/Practitioner.swift
+++ b/firekit/firekit/classes/models/Practitioner.swift
@@ -2,10 +2,10 @@
 //  Practitioner.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Practitioner) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Practitioner) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -120,7 +120,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.address.enumerated() {
             guard index < self.address.count else {
-                self.address.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Address()
+                val.populate(from: t)
+                self.address.append(val)
                 continue
             }
             self.address[index].populate(from: t)
@@ -135,7 +139,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.communication.enumerated() {
             guard index < self.communication.count else {
-                self.communication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.communication.append(val)
                 continue
             }
             self.communication[index].populate(from: t)
@@ -150,7 +158,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -165,7 +177,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.photo.enumerated() {
             guard index < self.photo.count else {
-                self.photo.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Attachment()
+                val.populate(from: t)
+                self.photo.append(val)
                 continue
             }
             self.photo[index].populate(from: t)
@@ -179,7 +195,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.practitionerRole.enumerated() {
             guard index < self.practitionerRole.count else {
-                self.practitionerRole.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PractitionerPractitionerRole()
+                val.populate(from: t)
+                self.practitionerRole.append(val)
                 continue
             }
             self.practitionerRole[index].populate(from: t)
@@ -193,7 +213,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.qualification.enumerated() {
             guard index < self.qualification.count else {
-                self.qualification.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = PractitionerQualification()
+                val.populate(from: t)
+                self.qualification.append(val)
                 continue
             }
             self.qualification[index].populate(from: t)
@@ -207,7 +231,11 @@ open class Practitioner: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -314,7 +342,11 @@ open class PractitionerPractitionerRole: BackboneElement {
 
         for (index, t) in o.healthcareService.enumerated() {
             guard index < self.healthcareService.count else {
-                self.healthcareService.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.healthcareService.append(val)
                 continue
             }
             self.healthcareService[index].populate(from: t)
@@ -328,7 +360,11 @@ open class PractitionerPractitionerRole: BackboneElement {
 
         for (index, t) in o.location.enumerated() {
             guard index < self.location.count else {
-                self.location.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.location.append(val)
                 continue
             }
             self.location[index].populate(from: t)
@@ -345,7 +381,11 @@ open class PractitionerPractitionerRole: BackboneElement {
 
         for (index, t) in o.specialty.enumerated() {
             guard index < self.specialty.count else {
-                self.specialty.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.specialty.append(val)
                 continue
             }
             self.specialty[index].populate(from: t)
@@ -449,7 +489,11 @@ open class PractitionerQualification: BackboneElement {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Procedure.swift
+++ b/firekit/firekit/classes/models/Procedure.swift
@@ -2,10 +2,10 @@
 //  Procedure.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Procedure) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Procedure) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -203,7 +203,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.bodySite.enumerated() {
             guard index < self.bodySite.count else {
-                self.bodySite.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.bodySite.append(val)
                 continue
             }
             self.bodySite[index].populate(from: t)
@@ -219,7 +223,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.complication.enumerated() {
             guard index < self.complication.count else {
-                self.complication.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.complication.append(val)
                 continue
             }
             self.complication[index].populate(from: t)
@@ -234,7 +242,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.focalDevice.enumerated() {
             guard index < self.focalDevice.count else {
-                self.focalDevice.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProcedureFocalDevice()
+                val.populate(from: t)
+                self.focalDevice.append(val)
                 continue
             }
             self.focalDevice[index].populate(from: t)
@@ -248,7 +260,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.followUp.enumerated() {
             guard index < self.followUp.count else {
-                self.followUp.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.followUp.append(val)
                 continue
             }
             self.followUp[index].populate(from: t)
@@ -262,7 +278,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -278,7 +298,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.notes.enumerated() {
             guard index < self.notes.count else {
-                self.notes.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.notes.append(val)
                 continue
             }
             self.notes[index].populate(from: t)
@@ -295,7 +319,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.performer.enumerated() {
             guard index < self.performer.count else {
-                self.performer.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProcedurePerformer()
+                val.populate(from: t)
+                self.performer.append(val)
                 continue
             }
             self.performer[index].populate(from: t)
@@ -310,7 +338,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.reasonNotPerformed.enumerated() {
             guard index < self.reasonNotPerformed.count else {
-                self.reasonNotPerformed.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reasonNotPerformed.append(val)
                 continue
             }
             self.reasonNotPerformed[index].populate(from: t)
@@ -325,7 +357,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.report.enumerated() {
             guard index < self.report.count else {
-                self.report.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.report.append(val)
                 continue
             }
             self.report[index].populate(from: t)
@@ -342,7 +378,11 @@ open class Procedure: DomainResource {
 
         for (index, t) in o.used.enumerated() {
             guard index < self.used.count else {
-                self.used.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.used.append(val)
                 continue
             }
             self.used[index].populate(from: t)

--- a/firekit/firekit/classes/models/ProcedureRequest.swift
+++ b/firekit/firekit/classes/models/ProcedureRequest.swift
@@ -2,10 +2,10 @@
 //  ProcedureRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcedureRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcedureRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -183,7 +183,11 @@ open class ProcedureRequest: DomainResource {
 
         for (index, t) in o.bodySite.enumerated() {
             guard index < self.bodySite.count else {
-                self.bodySite.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.bodySite.append(val)
                 continue
             }
             self.bodySite[index].populate(from: t)
@@ -199,7 +203,11 @@ open class ProcedureRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -213,7 +221,11 @@ open class ProcedureRequest: DomainResource {
 
         for (index, t) in o.notes.enumerated() {
             guard index < self.notes.count else {
-                self.notes.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Annotation()
+                val.populate(from: t)
+                self.notes.append(val)
                 continue
             }
             self.notes[index].populate(from: t)

--- a/firekit/firekit/classes/models/ProcessRequest.swift
+++ b/firekit/firekit/classes/models/ProcessRequest.swift
@@ -2,10 +2,10 @@
 //  ProcessRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -169,7 +169,11 @@ open class ProcessRequest: DomainResource {
 
         for (index, t) in o.exclude.enumerated() {
             guard index < self.exclude.count else {
-                self.exclude.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.exclude.append(val)
                 continue
             }
             self.exclude[index].populate(from: t)
@@ -183,7 +187,11 @@ open class ProcessRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -197,7 +205,11 @@ open class ProcessRequest: DomainResource {
 
         for (index, t) in o.include.enumerated() {
             guard index < self.include.count else {
-                self.include.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.include.append(val)
                 continue
             }
             self.include[index].populate(from: t)
@@ -211,7 +223,11 @@ open class ProcessRequest: DomainResource {
 
         for (index, t) in o.item.enumerated() {
             guard index < self.item.count else {
-                self.item.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProcessRequestItem()
+                val.populate(from: t)
+                self.item.append(val)
                 continue
             }
             self.item[index].populate(from: t)

--- a/firekit/firekit/classes/models/ProcessResponse.swift
+++ b/firekit/firekit/classes/models/ProcessResponse.swift
@@ -2,10 +2,10 @@
 //  ProcessResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ProcessResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -150,7 +150,11 @@ open class ProcessResponse: DomainResource {
 
         for (index, t) in o.error.enumerated() {
             guard index < self.error.count else {
-                self.error.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.error.append(val)
                 continue
             }
             self.error[index].populate(from: t)
@@ -165,7 +169,11 @@ open class ProcessResponse: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -179,7 +187,11 @@ open class ProcessResponse: DomainResource {
 
         for (index, t) in o.notes.enumerated() {
             guard index < self.notes.count else {
-                self.notes.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProcessResponseNotes()
+                val.populate(from: t)
+                self.notes.append(val)
                 continue
             }
             self.notes[index].populate(from: t)

--- a/firekit/firekit/classes/models/Provenance.swift
+++ b/firekit/firekit/classes/models/Provenance.swift
@@ -2,10 +2,10 @@
 //  Provenance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Provenance) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Provenance) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -135,7 +135,11 @@ open class Provenance: DomainResource {
 
         for (index, t) in o.agent.enumerated() {
             guard index < self.agent.count else {
-                self.agent.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProvenanceAgent()
+                val.populate(from: t)
+                self.agent.append(val)
                 continue
             }
             self.agent[index].populate(from: t)
@@ -149,7 +153,11 @@ open class Provenance: DomainResource {
 
         for (index, t) in o.entity.enumerated() {
             guard index < self.entity.count else {
-                self.entity.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProvenanceEntity()
+                val.populate(from: t)
+                self.entity.append(val)
                 continue
             }
             self.entity[index].populate(from: t)
@@ -165,7 +173,11 @@ open class Provenance: DomainResource {
 
         for (index, t) in o.policy.enumerated() {
             guard index < self.policy.count else {
-                self.policy.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.policy.append(val)
                 continue
             }
             self.policy[index].populate(from: t)
@@ -179,7 +191,11 @@ open class Provenance: DomainResource {
 
         for (index, t) in o.reason.enumerated() {
             guard index < self.reason.count else {
-                self.reason.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.reason.append(val)
                 continue
             }
             self.reason[index].populate(from: t)
@@ -194,7 +210,11 @@ open class Provenance: DomainResource {
 
         for (index, t) in o.signature.enumerated() {
             guard index < self.signature.count else {
-                self.signature.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Signature()
+                val.populate(from: t)
+                self.signature.append(val)
                 continue
             }
             self.signature[index].populate(from: t)
@@ -208,7 +228,11 @@ open class Provenance: DomainResource {
 
         for (index, t) in o.target.enumerated() {
             guard index < self.target.count else {
-                self.target.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.target.append(val)
                 continue
             }
             self.target[index].populate(from: t)
@@ -316,7 +340,11 @@ open class ProvenanceAgent: BackboneElement {
 
         for (index, t) in o.relatedAgent.enumerated() {
             guard index < self.relatedAgent.count else {
-                self.relatedAgent.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ProvenanceAgentRelatedAgent()
+                val.populate(from: t)
+                self.relatedAgent.append(val)
                 continue
             }
             self.relatedAgent[index].populate(from: t)

--- a/firekit/firekit/classes/models/Quantity.swift
+++ b/firekit/firekit/classes/models/Quantity.swift
@@ -2,10 +2,10 @@
 //  Quantity.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Quantity) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Quantity) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Questionnaire.swift
+++ b/firekit/firekit/classes/models/Questionnaire.swift
@@ -2,10 +2,10 @@
 //  Questionnaire.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Questionnaire) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Questionnaire) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -117,7 +117,11 @@ open class Questionnaire: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -133,7 +137,11 @@ open class Questionnaire: DomainResource {
 
         for (index, t) in o.subjectType.enumerated() {
             guard index < self.subjectType.count else {
-                self.subjectType.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.subjectType.append(val)
                 continue
             }
             self.subjectType[index].populate(from: t)
@@ -147,7 +155,11 @@ open class Questionnaire: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -254,7 +266,11 @@ open class QuestionnaireGroup: BackboneElement {
 
         for (index, t) in o.concept.enumerated() {
             guard index < self.concept.count else {
-                self.concept.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.concept.append(val)
                 continue
             }
             self.concept[index].populate(from: t)
@@ -268,7 +284,11 @@ open class QuestionnaireGroup: BackboneElement {
 
         for (index, t) in o.group.enumerated() {
             guard index < self.group.count else {
-                self.group.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireGroup()
+                val.populate(from: t)
+                self.group.append(val)
                 continue
             }
             self.group[index].populate(from: t)
@@ -283,7 +303,11 @@ open class QuestionnaireGroup: BackboneElement {
 
         for (index, t) in o.question.enumerated() {
             guard index < self.question.count else {
-                self.question.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireGroupQuestion()
+                val.populate(from: t)
+                self.question.append(val)
                 continue
             }
             self.question[index].populate(from: t)
@@ -400,7 +424,11 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 
         for (index, t) in o.concept.enumerated() {
             guard index < self.concept.count else {
-                self.concept.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.concept.append(val)
                 continue
             }
             self.concept[index].populate(from: t)
@@ -414,7 +442,11 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 
         for (index, t) in o.group.enumerated() {
             guard index < self.group.count else {
-                self.group.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireGroup()
+                val.populate(from: t)
+                self.group.append(val)
                 continue
             }
             self.group[index].populate(from: t)
@@ -429,7 +461,11 @@ open class QuestionnaireGroupQuestion: BackboneElement {
 
         for (index, t) in o.option.enumerated() {
             guard index < self.option.count else {
-                self.option.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.option.append(val)
                 continue
             }
             self.option[index].populate(from: t)

--- a/firekit/firekit/classes/models/QuestionnaireResponse.swift
+++ b/firekit/firekit/classes/models/QuestionnaireResponse.swift
@@ -2,10 +2,10 @@
 //  QuestionnaireResponse.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -232,7 +232,11 @@ open class QuestionnaireResponseGroup: BackboneElement {
 
         for (index, t) in o.group.enumerated() {
             guard index < self.group.count else {
-                self.group.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireResponseGroup()
+                val.populate(from: t)
+                self.group.append(val)
                 continue
             }
             self.group[index].populate(from: t)
@@ -247,7 +251,11 @@ open class QuestionnaireResponseGroup: BackboneElement {
 
         for (index, t) in o.question.enumerated() {
             guard index < self.question.count else {
-                self.question.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireResponseGroupQuestion()
+                val.populate(from: t)
+                self.question.append(val)
                 continue
             }
             self.question[index].populate(from: t)
@@ -336,7 +344,11 @@ open class QuestionnaireResponseGroupQuestion: BackboneElement {
 
         for (index, t) in o.answer.enumerated() {
             guard index < self.answer.count else {
-                self.answer.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireResponseGroupQuestionAnswer()
+                val.populate(from: t)
+                self.answer.append(val)
                 continue
             }
             self.answer[index].populate(from: t)
@@ -480,7 +492,11 @@ open class QuestionnaireResponseGroupQuestionAnswer: BackboneElement {
 
         for (index, t) in o.group.enumerated() {
             guard index < self.group.count else {
-                self.group.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = QuestionnaireResponseGroup()
+                val.populate(from: t)
+                self.group.append(val)
                 continue
             }
             self.group[index].populate(from: t)

--- a/firekit/firekit/classes/models/Range.swift
+++ b/firekit/firekit/classes/models/Range.swift
@@ -2,10 +2,10 @@
 //  Range.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Range) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Range) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Ratio.swift
+++ b/firekit/firekit/classes/models/Ratio.swift
@@ -2,10 +2,10 @@
 //  Ratio.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Ratio) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Ratio) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/RealmTypes.swift
+++ b/firekit/firekit/classes/models/RealmTypes.swift
@@ -42,6 +42,14 @@ extension RealmString: Populatable {
     }
 }
 
+extension RealmString: NSCopying {
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = RealmString()
+        copy.value = value
+        return copy
+    }
+}
+
 final public class RealmInt: Object, Codable {
     @objc public dynamic var pk: String = UUID().uuidString
     @objc public dynamic var value: Int = 0
@@ -71,6 +79,14 @@ extension RealmInt: Populatable {
             return
         }
         value = o.value
+    }
+}
+
+extension RealmInt: NSCopying {
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = RealmInt()
+        copy.value = value
+        return copy
     }
 }
 
@@ -149,6 +165,14 @@ extension RealmDecimal: Populatable {
     }
 }
 
+extension RealmDecimal: NSCopying {
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = RealmDecimal()
+        copy.value = value
+        return copy
+    }
+}
+
 final public class RealmURL: Object, Codable {
     @objc public dynamic var pk: String = UUID().uuidString
     @objc private dynamic var _value: String?
@@ -193,6 +217,14 @@ extension RealmURL: Populatable {
             return
         }
         _value = o._value
+    }
+}
+
+extension RealmURL: NSCopying {
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let copy = RealmURL()
+        copy.value = value
+        return copy
     }
 }
 
@@ -266,5 +298,17 @@ final public class ContainedResource: Resource {
         super.populate(from: other)
         resourceType = o.resourceType
         json = o.json
+    }
+    
+    public override func copy(with zone: NSZone? = nil) -> Any {
+        let copy = ContainedResource()
+        copy._versionId = _versionId
+        copy.id = id
+        copy.implicitRules = implicitRules
+        copy.language = language
+        copy.upsert(meta: meta)
+        copy.resourceType = resourceType
+        copy.json = json
+        return copy
     }
 }

--- a/firekit/firekit/classes/models/Reference.swift
+++ b/firekit/firekit/classes/models/Reference.swift
@@ -2,10 +2,10 @@
 //  Reference.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Reference) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Reference) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/ReferralRequest.swift
+++ b/firekit/firekit/classes/models/ReferralRequest.swift
@@ -2,10 +2,10 @@
 //  ReferralRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ReferralRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ReferralRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -172,7 +172,11 @@ open class ReferralRequest: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -189,7 +193,11 @@ open class ReferralRequest: DomainResource {
 
         for (index, t) in o.recipient.enumerated() {
             guard index < self.recipient.count else {
-                self.recipient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.recipient.append(val)
                 continue
             }
             self.recipient[index].populate(from: t)
@@ -204,7 +212,11 @@ open class ReferralRequest: DomainResource {
 
         for (index, t) in o.serviceRequested.enumerated() {
             guard index < self.serviceRequested.count else {
-                self.serviceRequested.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.serviceRequested.append(val)
                 continue
             }
             self.serviceRequested[index].populate(from: t)
@@ -220,7 +232,11 @@ open class ReferralRequest: DomainResource {
 
         for (index, t) in o.supportingInformation.enumerated() {
             guard index < self.supportingInformation.count else {
-                self.supportingInformation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.supportingInformation.append(val)
                 continue
             }
             self.supportingInformation[index].populate(from: t)

--- a/firekit/firekit/classes/models/RelatedPerson.swift
+++ b/firekit/firekit/classes/models/RelatedPerson.swift
@@ -2,10 +2,10 @@
 //  RelatedPerson.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RelatedPerson) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RelatedPerson) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -131,7 +131,11 @@ open class RelatedPerson: DomainResource {
 
         for (index, t) in o.address.enumerated() {
             guard index < self.address.count else {
-                self.address.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Address()
+                val.populate(from: t)
+                self.address.append(val)
                 continue
             }
             self.address[index].populate(from: t)
@@ -147,7 +151,11 @@ open class RelatedPerson: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -164,7 +172,11 @@ open class RelatedPerson: DomainResource {
 
         for (index, t) in o.photo.enumerated() {
             guard index < self.photo.count else {
-                self.photo.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Attachment()
+                val.populate(from: t)
+                self.photo.append(val)
                 continue
             }
             self.photo[index].populate(from: t)
@@ -179,7 +191,11 @@ open class RelatedPerson: DomainResource {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/Resource.swift
+++ b/firekit/firekit/classes/models/Resource.swift
@@ -2,10 +2,10 @@
 //  Resource.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Resource) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Resource) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/RiskAssessment.swift
+++ b/firekit/firekit/classes/models/RiskAssessment.swift
@@ -2,10 +2,10 @@
 //  RiskAssessment.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RiskAssessment) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/RiskAssessment) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -130,7 +130,11 @@ open class RiskAssessment: DomainResource {
 
         for (index, t) in o.basis.enumerated() {
             guard index < self.basis.count else {
-                self.basis.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.basis.append(val)
                 continue
             }
             self.basis[index].populate(from: t)
@@ -151,7 +155,11 @@ open class RiskAssessment: DomainResource {
 
         for (index, t) in o.prediction.enumerated() {
             guard index < self.prediction.count else {
-                self.prediction.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RiskAssessmentPrediction()
+                val.populate(from: t)
+                self.prediction.append(val)
                 continue
             }
             self.prediction[index].populate(from: t)

--- a/firekit/firekit/classes/models/SampledData.swift
+++ b/firekit/firekit/classes/models/SampledData.swift
@@ -2,10 +2,10 @@
 //  SampledData.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SampledData) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SampledData) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation

--- a/firekit/firekit/classes/models/Schedule.swift
+++ b/firekit/firekit/classes/models/Schedule.swift
@@ -2,10 +2,10 @@
 //  Schedule.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Schedule) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Schedule) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -104,7 +104,11 @@ open class Schedule: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -119,7 +123,11 @@ open class Schedule: DomainResource {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)

--- a/firekit/firekit/classes/models/SearchParameter.swift
+++ b/firekit/firekit/classes/models/SearchParameter.swift
@@ -2,10 +2,10 @@
 //  SearchParameter.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SearchParameter) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SearchParameter) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -145,7 +145,11 @@ open class SearchParameter: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = SearchParameterContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -166,7 +170,11 @@ open class SearchParameter: DomainResource {
 
         for (index, t) in o.target.enumerated() {
             guard index < self.target.count else {
-                self.target.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.target.append(val)
                 continue
             }
             self.target[index].populate(from: t)
@@ -253,7 +261,11 @@ open class SearchParameterContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)

--- a/firekit/firekit/classes/models/Signature.swift
+++ b/firekit/firekit/classes/models/Signature.swift
@@ -2,10 +2,10 @@
 //  Signature.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Signature) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Signature) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -114,7 +114,11 @@ open class Signature: Element {
 
         for (index, t) in o.type.enumerated() {
             guard index < self.type.count else {
-                self.type.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.type.append(val)
                 continue
             }
             self.type[index].populate(from: t)

--- a/firekit/firekit/classes/models/Slot.swift
+++ b/firekit/firekit/classes/models/Slot.swift
@@ -2,10 +2,10 @@
 //  Slot.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Slot) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Slot) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -120,7 +120,11 @@ open class Slot: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekit/classes/models/Specimen.swift
+++ b/firekit/firekit/classes/models/Specimen.swift
@@ -2,10 +2,10 @@
 //  Specimen.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Specimen) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Specimen) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -132,7 +132,11 @@ open class Specimen: DomainResource {
 
         for (index, t) in o.container.enumerated() {
             guard index < self.container.count else {
-                self.container.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = SpecimenContainer()
+                val.populate(from: t)
+                self.container.append(val)
                 continue
             }
             self.container[index].populate(from: t)
@@ -146,7 +150,11 @@ open class Specimen: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -160,7 +168,11 @@ open class Specimen: DomainResource {
 
         for (index, t) in o.parent.enumerated() {
             guard index < self.parent.count else {
-                self.parent.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.parent.append(val)
                 continue
             }
             self.parent[index].populate(from: t)
@@ -177,7 +189,11 @@ open class Specimen: DomainResource {
 
         for (index, t) in o.treatment.enumerated() {
             guard index < self.treatment.count else {
-                self.treatment.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = SpecimenTreatment()
+                val.populate(from: t)
+                self.treatment.append(val)
                 continue
             }
             self.treatment[index].populate(from: t)
@@ -299,7 +315,11 @@ open class SpecimenCollection: BackboneElement {
 
         for (index, t) in o.comment.enumerated() {
             guard index < self.comment.count else {
-                self.comment.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.comment.append(val)
                 continue
             }
             self.comment[index].populate(from: t)
@@ -423,7 +443,11 @@ open class SpecimenContainer: BackboneElement {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -514,7 +538,11 @@ open class SpecimenTreatment: BackboneElement {
 
         for (index, t) in o.additive.enumerated() {
             guard index < self.additive.count else {
-                self.additive.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.additive.append(val)
                 continue
             }
             self.additive[index].populate(from: t)

--- a/firekit/firekit/classes/models/StructureDefinition.swift
+++ b/firekit/firekit/classes/models/StructureDefinition.swift
@@ -2,10 +2,10 @@
 //  StructureDefinition.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/StructureDefinition) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/StructureDefinition) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -191,7 +191,11 @@ open class StructureDefinition: DomainResource {
 
         for (index, t) in o.code.enumerated() {
             guard index < self.code.count else {
-                self.code.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.code.append(val)
                 continue
             }
             self.code[index].populate(from: t)
@@ -206,7 +210,11 @@ open class StructureDefinition: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = StructureDefinitionContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -220,7 +228,11 @@ open class StructureDefinition: DomainResource {
 
         for (index, t) in o.context.enumerated() {
             guard index < self.context.count else {
-                self.context.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.context.append(val)
                 continue
             }
             self.context[index].populate(from: t)
@@ -242,7 +254,11 @@ open class StructureDefinition: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -257,7 +273,11 @@ open class StructureDefinition: DomainResource {
 
         for (index, t) in o.mapping.enumerated() {
             guard index < self.mapping.count else {
-                self.mapping.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = StructureDefinitionMapping()
+                val.populate(from: t)
+                self.mapping.append(val)
                 continue
             }
             self.mapping[index].populate(from: t)
@@ -277,7 +297,11 @@ open class StructureDefinition: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -361,7 +385,11 @@ open class StructureDefinitionContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -446,7 +474,11 @@ open class StructureDefinitionDifferential: BackboneElement {
 
         for (index, t) in o.element.enumerated() {
             guard index < self.element.count else {
-                self.element.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ElementDefinition()
+                val.populate(from: t)
+                self.element.append(val)
                 continue
             }
             self.element[index].populate(from: t)
@@ -617,7 +649,11 @@ open class StructureDefinitionSnapshot: BackboneElement {
 
         for (index, t) in o.element.enumerated() {
             guard index < self.element.count else {
-                self.element.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ElementDefinition()
+                val.populate(from: t)
+                self.element.append(val)
                 continue
             }
             self.element[index].populate(from: t)

--- a/firekit/firekit/classes/models/Subscription.swift
+++ b/firekit/firekit/classes/models/Subscription.swift
@@ -2,10 +2,10 @@
 //  Subscription.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Subscription) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Subscription) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -120,7 +120,11 @@ open class Subscription: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -139,7 +143,11 @@ open class Subscription: DomainResource {
 
         for (index, t) in o.tag.enumerated() {
             guard index < self.tag.count else {
-                self.tag.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Coding()
+                val.populate(from: t)
+                self.tag.append(val)
                 continue
             }
             self.tag[index].populate(from: t)

--- a/firekit/firekit/classes/models/Substance.swift
+++ b/firekit/firekit/classes/models/Substance.swift
@@ -2,10 +2,10 @@
 //  Substance.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Substance) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Substance) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -103,7 +103,11 @@ open class Substance: DomainResource {
 
         for (index, t) in o.category.enumerated() {
             guard index < self.category.count else {
-                self.category.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.category.append(val)
                 continue
             }
             self.category[index].populate(from: t)
@@ -119,7 +123,11 @@ open class Substance: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)
@@ -133,7 +141,11 @@ open class Substance: DomainResource {
 
         for (index, t) in o.ingredient.enumerated() {
             guard index < self.ingredient.count else {
-                self.ingredient.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = SubstanceIngredient()
+                val.populate(from: t)
+                self.ingredient.append(val)
                 continue
             }
             self.ingredient[index].populate(from: t)
@@ -147,7 +159,11 @@ open class Substance: DomainResource {
 
         for (index, t) in o.instance.enumerated() {
             guard index < self.instance.count else {
-                self.instance.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = SubstanceInstance()
+                val.populate(from: t)
+                self.instance.append(val)
                 continue
             }
             self.instance[index].populate(from: t)

--- a/firekit/firekit/classes/models/SupplyDelivery.swift
+++ b/firekit/firekit/classes/models/SupplyDelivery.swift
@@ -2,10 +2,10 @@
 //  SupplyDelivery.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyDelivery) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyDelivery) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -144,7 +144,11 @@ open class SupplyDelivery: DomainResource {
 
         for (index, t) in o.receiver.enumerated() {
             guard index < self.receiver.count else {
-                self.receiver.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.receiver.append(val)
                 continue
             }
             self.receiver[index].populate(from: t)

--- a/firekit/firekit/classes/models/SupplyRequest.swift
+++ b/firekit/firekit/classes/models/SupplyRequest.swift
@@ -2,10 +2,10 @@
 //  SupplyRequest.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyRequest) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/SupplyRequest) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -149,7 +149,11 @@ open class SupplyRequest: DomainResource {
 
         for (index, t) in o.supplier.enumerated() {
             guard index < self.supplier.count else {
-                self.supplier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.supplier.append(val)
                 continue
             }
             self.supplier[index].populate(from: t)

--- a/firekit/firekit/classes/models/TestScript.swift
+++ b/firekit/firekit/classes/models/TestScript.swift
@@ -2,10 +2,10 @@
 //  TestScript.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/TestScript) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/TestScript) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -177,7 +177,11 @@ open class TestScript: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -195,7 +199,11 @@ open class TestScript: DomainResource {
 
         for (index, t) in o.fixture.enumerated() {
             guard index < self.fixture.count else {
-                self.fixture.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptFixture()
+                val.populate(from: t)
+                self.fixture.append(val)
                 continue
             }
             self.fixture[index].populate(from: t)
@@ -213,7 +221,11 @@ open class TestScript: DomainResource {
 
         for (index, t) in o.profile.enumerated() {
             guard index < self.profile.count else {
-                self.profile.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Reference()
+                val.populate(from: t)
+                self.profile.append(val)
                 continue
             }
             self.profile[index].populate(from: t)
@@ -232,7 +244,11 @@ open class TestScript: DomainResource {
 
         for (index, t) in o.test.enumerated() {
             guard index < self.test.count else {
-                self.test.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptTest()
+                val.populate(from: t)
+                self.test.append(val)
                 continue
             }
             self.test[index].populate(from: t)
@@ -247,7 +263,11 @@ open class TestScript: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -261,7 +281,11 @@ open class TestScript: DomainResource {
 
         for (index, t) in o.variable.enumerated() {
             guard index < self.variable.count else {
-                self.variable.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptVariable()
+                val.populate(from: t)
+                self.variable.append(val)
                 continue
             }
             self.variable[index].populate(from: t)
@@ -345,7 +369,11 @@ open class TestScriptContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -511,7 +539,11 @@ open class TestScriptMetadata: BackboneElement {
 
         for (index, t) in o.capability.enumerated() {
             guard index < self.capability.count else {
-                self.capability.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptMetadataCapability()
+                val.populate(from: t)
+                self.capability.append(val)
                 continue
             }
             self.capability[index].populate(from: t)
@@ -525,7 +557,11 @@ open class TestScriptMetadata: BackboneElement {
 
         for (index, t) in o.link.enumerated() {
             guard index < self.link.count else {
-                self.link.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptMetadataLink()
+                val.populate(from: t)
+                self.link.append(val)
                 continue
             }
             self.link[index].populate(from: t)
@@ -635,7 +671,11 @@ open class TestScriptMetadataCapability: BackboneElement {
 
         for (index, t) in o.link.enumerated() {
             guard index < self.link.count else {
-                self.link.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.link.append(val)
                 continue
             }
             self.link[index].populate(from: t)
@@ -802,7 +842,11 @@ open class TestScriptSetup: BackboneElement {
 
         for (index, t) in o.action.enumerated() {
             guard index < self.action.count else {
-                self.action.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptSetupAction()
+                val.populate(from: t)
+                self.action.append(val)
                 continue
             }
             self.action[index].populate(from: t)
@@ -1169,7 +1213,11 @@ open class TestScriptSetupActionOperation: BackboneElement {
 
         for (index, t) in o.requestHeader.enumerated() {
             guard index < self.requestHeader.count else {
-                self.requestHeader.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptSetupActionOperationRequestHeader()
+                val.populate(from: t)
+                self.requestHeader.append(val)
                 continue
             }
             self.requestHeader[index].populate(from: t)
@@ -1336,7 +1384,11 @@ open class TestScriptTeardown: BackboneElement {
 
         for (index, t) in o.action.enumerated() {
             guard index < self.action.count else {
-                self.action.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptTeardownAction()
+                val.populate(from: t)
+                self.action.append(val)
                 continue
             }
             self.action[index].populate(from: t)
@@ -1501,7 +1553,11 @@ open class TestScriptTest: BackboneElement {
 
         for (index, t) in o.action.enumerated() {
             guard index < self.action.count else {
-                self.action.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = TestScriptTestAction()
+                val.populate(from: t)
+                self.action.append(val)
                 continue
             }
             self.action[index].populate(from: t)

--- a/firekit/firekit/classes/models/Timing.swift
+++ b/firekit/firekit/classes/models/Timing.swift
@@ -2,10 +2,10 @@
 //  Timing.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Timing) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/Timing) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -93,7 +93,11 @@ open class Timing: Element {
 
         for (index, t) in o.event.enumerated() {
             guard index < self.event.count else {
-                self.event.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = DateTime()
+                val.populate(from: t)
+                self.event.append(val)
                 continue
             }
             self.event[index].populate(from: t)

--- a/firekit/firekit/classes/models/ValueSet.swift
+++ b/firekit/firekit/classes/models/ValueSet.swift
@@ -2,10 +2,10 @@
 //  ValueSet.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ValueSet) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/ValueSet) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -168,7 +168,11 @@ open class ValueSet: DomainResource {
 
         for (index, t) in o.contact.enumerated() {
             guard index < self.contact.count else {
-                self.contact.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetContact()
+                val.populate(from: t)
+                self.contact.append(val)
                 continue
             }
             self.contact[index].populate(from: t)
@@ -196,7 +200,11 @@ open class ValueSet: DomainResource {
 
         for (index, t) in o.useContext.enumerated() {
             guard index < self.useContext.count else {
-                self.useContext.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = CodeableConcept()
+                val.populate(from: t)
+                self.useContext.append(val)
                 continue
             }
             self.useContext[index].populate(from: t)
@@ -296,7 +304,11 @@ open class ValueSetCodeSystem: BackboneElement {
 
         for (index, t) in o.concept.enumerated() {
             guard index < self.concept.count else {
-                self.concept.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetCodeSystemConcept()
+                val.populate(from: t)
+                self.concept.append(val)
                 continue
             }
             self.concept[index].populate(from: t)
@@ -405,7 +417,11 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 
         for (index, t) in o.concept.enumerated() {
             guard index < self.concept.count else {
-                self.concept.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetCodeSystemConcept()
+                val.populate(from: t)
+                self.concept.append(val)
                 continue
             }
             self.concept[index].populate(from: t)
@@ -420,7 +436,11 @@ open class ValueSetCodeSystemConcept: BackboneElement {
 
         for (index, t) in o.designation.enumerated() {
             guard index < self.designation.count else {
-                self.designation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetCodeSystemConceptDesignation()
+                val.populate(from: t)
+                self.designation.append(val)
                 continue
             }
             self.designation[index].populate(from: t)
@@ -593,7 +613,11 @@ open class ValueSetCompose: BackboneElement {
 
         for (index, t) in o.exclude.enumerated() {
             guard index < self.exclude.count else {
-                self.exclude.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetComposeInclude()
+                val.populate(from: t)
+                self.exclude.append(val)
                 continue
             }
             self.exclude[index].populate(from: t)
@@ -607,7 +631,11 @@ open class ValueSetCompose: BackboneElement {
 
         for (index, t) in o.import_fhir.enumerated() {
             guard index < self.import_fhir.count else {
-                self.import_fhir.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = RealmString()
+                val.populate(from: t)
+                self.import_fhir.append(val)
                 continue
             }
             self.import_fhir[index].populate(from: t)
@@ -621,7 +649,11 @@ open class ValueSetCompose: BackboneElement {
 
         for (index, t) in o.include.enumerated() {
             guard index < self.include.count else {
-                self.include.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetComposeInclude()
+                val.populate(from: t)
+                self.include.append(val)
                 continue
             }
             self.include[index].populate(from: t)
@@ -715,7 +747,11 @@ open class ValueSetComposeInclude: BackboneElement {
 
         for (index, t) in o.concept.enumerated() {
             guard index < self.concept.count else {
-                self.concept.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetComposeIncludeConcept()
+                val.populate(from: t)
+                self.concept.append(val)
                 continue
             }
             self.concept[index].populate(from: t)
@@ -729,7 +765,11 @@ open class ValueSetComposeInclude: BackboneElement {
 
         for (index, t) in o.filter.enumerated() {
             guard index < self.filter.count else {
-                self.filter.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetComposeIncludeFilter()
+                val.populate(from: t)
+                self.filter.append(val)
                 continue
             }
             self.filter[index].populate(from: t)
@@ -824,7 +864,11 @@ open class ValueSetComposeIncludeConcept: BackboneElement {
 
         for (index, t) in o.designation.enumerated() {
             guard index < self.designation.count else {
-                self.designation.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetCodeSystemConceptDesignation()
+                val.populate(from: t)
+                self.designation.append(val)
                 continue
             }
             self.designation[index].populate(from: t)
@@ -992,7 +1036,11 @@ open class ValueSetContact: BackboneElement {
 
         for (index, t) in o.telecom.enumerated() {
             guard index < self.telecom.count else {
-                self.telecom.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ContactPoint()
+                val.populate(from: t)
+                self.telecom.append(val)
                 continue
             }
             self.telecom[index].populate(from: t)
@@ -1098,7 +1146,11 @@ open class ValueSetExpansion: BackboneElement {
 
         for (index, t) in o.contains.enumerated() {
             guard index < self.contains.count else {
-                self.contains.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetExpansionContains()
+                val.populate(from: t)
+                self.contains.append(val)
                 continue
             }
             self.contains[index].populate(from: t)
@@ -1114,7 +1166,11 @@ open class ValueSetExpansion: BackboneElement {
 
         for (index, t) in o.parameter.enumerated() {
             guard index < self.parameter.count else {
-                self.parameter.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetExpansionParameter()
+                val.populate(from: t)
+                self.parameter.append(val)
                 continue
             }
             self.parameter[index].populate(from: t)
@@ -1216,7 +1272,11 @@ open class ValueSetExpansionContains: BackboneElement {
 
         for (index, t) in o.contains.enumerated() {
             guard index < self.contains.count else {
-                self.contains.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = ValueSetExpansionContains()
+                val.populate(from: t)
+                self.contains.append(val)
                 continue
             }
             self.contains[index].populate(from: t)

--- a/firekit/firekit/classes/models/VisionPrescription.swift
+++ b/firekit/firekit/classes/models/VisionPrescription.swift
@@ -2,10 +2,10 @@
 //  VisionPrescription.swift
 //  SwiftFHIR
 //
-//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/VisionPrescription) on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 (http://hl7.org/fhir/StructureDefinition/VisionPrescription) on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// 	Updated for Realm support by Ryan Baldwin on 2017-10-22
+// 	Updated for Realm support by Ryan Baldwin on 2017-11-07
 // 	Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 
 import Foundation
@@ -120,7 +120,11 @@ open class VisionPrescription: DomainResource {
 
         for (index, t) in o.dispense.enumerated() {
             guard index < self.dispense.count else {
-                self.dispense.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = VisionPrescriptionDispense()
+                val.populate(from: t)
+                self.dispense.append(val)
                 continue
             }
             self.dispense[index].populate(from: t)
@@ -135,7 +139,11 @@ open class VisionPrescription: DomainResource {
 
         for (index, t) in o.identifier.enumerated() {
             guard index < self.identifier.count else {
-                self.identifier.append(t)
+                // we should always copy in case the same source is being used across several targets
+                // in a single transaction.
+                let val = Identifier()
+                val.populate(from: t)
+                self.identifier.append(val)
                 continue
             }
             self.identifier[index].populate(from: t)

--- a/firekit/firekitTests/FHIRAbstractBaseTests.swift
+++ b/firekit/firekitTests/FHIRAbstractBaseTests.swift
@@ -1,0 +1,54 @@
+//
+//  FHIRAbstractBaseTests.swift
+//  FireKit-iOSTests
+//
+//  Created by Ryan Baldwin on 2017-11-08.
+//  Copyright © 2017 Bunnyhug. All rights reserved.
+//
+
+import XCTest
+import RealmSwift
+import FireKit
+
+class FHIRAbstractBaseTests: XCTestCase, RealmPersistenceTesting {
+    var realm: Realm!
+    
+    override func setUp() {
+        super.setUp()
+        realm = makeRealm()
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        clear(realm)
+    }
+    
+    func testUpsertingElementCompartmentalizesTheElement() {
+        let (patientA, patientB) = (Patient(), Patient())
+        
+        let coding = Coding()
+        coding.system = "2.16.840.1.113883.4.642.1.19"
+        coding.code = "M"
+        let maritalStatus = CodeableConcept()
+        maritalStatus.coding.append(coding)
+        
+        try! realm.write {
+            realm.add([patientA, patientB])
+            patientA.upsert(maritalStatus: maritalStatus)
+            patientB.upsert(maritalStatus: maritalStatus)
+        }
+        
+        XCTAssertNotNil(patientA.maritalStatus)
+        XCTAssertNotNil(patientB.maritalStatus)
+        XCTAssertEqual(2, realm.objects(CodeableConcept.self).count)
+        
+        try! realm.write {
+            patientB.upsert(maritalStatus: nil)
+        }
+        
+        XCTAssertNotNil(patientA.maritalStatus)
+        XCTAssertNil(patientB.maritalStatus)
+        XCTAssertEqual(1, realm.objects(CodeableConcept.self).count)
+    }
+}

--- a/firekit/firekitTests/classes/AccountTests.swift
+++ b/firekit/firekitTests/classes/AccountTests.swift
@@ -2,10 +2,10 @@
 //  AccountTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/AllergyIntoleranceTests.swift
+++ b/firekit/firekitTests/classes/AllergyIntoleranceTests.swift
@@ -2,10 +2,10 @@
 //  AllergyIntoleranceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/AppointmentResponseTests.swift
+++ b/firekit/firekitTests/classes/AppointmentResponseTests.swift
@@ -2,10 +2,10 @@
 //  AppointmentResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/AppointmentTests.swift
+++ b/firekit/firekitTests/classes/AppointmentTests.swift
@@ -2,10 +2,10 @@
 //  AppointmentTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/AuditEventTests.swift
+++ b/firekit/firekitTests/classes/AuditEventTests.swift
@@ -2,10 +2,10 @@
 //  AuditEventTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/BasicTests.swift
+++ b/firekit/firekitTests/classes/BasicTests.swift
@@ -2,10 +2,10 @@
 //  BasicTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/BinaryTests.swift
+++ b/firekit/firekitTests/classes/BinaryTests.swift
@@ -2,10 +2,10 @@
 //  BinaryTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/BodySiteTests.swift
+++ b/firekit/firekitTests/classes/BodySiteTests.swift
@@ -2,10 +2,10 @@
 //  BodySiteTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/BundleTests.swift
+++ b/firekit/firekitTests/classes/BundleTests.swift
@@ -2,10 +2,10 @@
 //  BundleTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/CarePlanTests.swift
+++ b/firekit/firekitTests/classes/CarePlanTests.swift
@@ -2,10 +2,10 @@
 //  CarePlanTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ClaimResponseTests.swift
+++ b/firekit/firekitTests/classes/ClaimResponseTests.swift
@@ -2,10 +2,10 @@
 //  ClaimResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ClaimTests.swift
+++ b/firekit/firekitTests/classes/ClaimTests.swift
@@ -2,10 +2,10 @@
 //  ClaimTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ClinicalImpressionTests.swift
+++ b/firekit/firekitTests/classes/ClinicalImpressionTests.swift
@@ -2,10 +2,10 @@
 //  ClinicalImpressionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/CommunicationRequestTests.swift
+++ b/firekit/firekitTests/classes/CommunicationRequestTests.swift
@@ -2,10 +2,10 @@
 //  CommunicationRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/CommunicationTests.swift
+++ b/firekit/firekitTests/classes/CommunicationTests.swift
@@ -2,10 +2,10 @@
 //  CommunicationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/CompositionTests.swift
+++ b/firekit/firekitTests/classes/CompositionTests.swift
@@ -2,10 +2,10 @@
 //  CompositionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ConceptMapTests.swift
+++ b/firekit/firekitTests/classes/ConceptMapTests.swift
@@ -2,10 +2,10 @@
 //  ConceptMapTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ConditionTests.swift
+++ b/firekit/firekitTests/classes/ConditionTests.swift
@@ -2,10 +2,10 @@
 //  ConditionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ConformanceTests.swift
+++ b/firekit/firekitTests/classes/ConformanceTests.swift
@@ -2,10 +2,10 @@
 //  ConformanceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ContractTests.swift
+++ b/firekit/firekitTests/classes/ContractTests.swift
@@ -2,10 +2,10 @@
 //  ContractTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/CoverageTests.swift
+++ b/firekit/firekitTests/classes/CoverageTests.swift
@@ -2,10 +2,10 @@
 //  CoverageTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DataElementTests.swift
+++ b/firekit/firekitTests/classes/DataElementTests.swift
@@ -2,10 +2,10 @@
 //  DataElementTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DetectedIssueTests.swift
+++ b/firekit/firekitTests/classes/DetectedIssueTests.swift
@@ -2,10 +2,10 @@
 //  DetectedIssueTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DeviceComponentTests.swift
+++ b/firekit/firekitTests/classes/DeviceComponentTests.swift
@@ -2,10 +2,10 @@
 //  DeviceComponentTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DeviceMetricTests.swift
+++ b/firekit/firekitTests/classes/DeviceMetricTests.swift
@@ -2,10 +2,10 @@
 //  DeviceMetricTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DeviceTests.swift
+++ b/firekit/firekitTests/classes/DeviceTests.swift
@@ -2,10 +2,10 @@
 //  DeviceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DeviceUseRequestTests.swift
+++ b/firekit/firekitTests/classes/DeviceUseRequestTests.swift
@@ -2,10 +2,10 @@
 //  DeviceUseRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DeviceUseStatementTests.swift
+++ b/firekit/firekitTests/classes/DeviceUseStatementTests.swift
@@ -2,10 +2,10 @@
 //  DeviceUseStatementTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DiagnosticOrderTests.swift
+++ b/firekit/firekitTests/classes/DiagnosticOrderTests.swift
@@ -2,10 +2,10 @@
 //  DiagnosticOrderTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DiagnosticReportTests.swift
+++ b/firekit/firekitTests/classes/DiagnosticReportTests.swift
@@ -2,10 +2,10 @@
 //  DiagnosticReportTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DocumentManifestTests.swift
+++ b/firekit/firekitTests/classes/DocumentManifestTests.swift
@@ -2,10 +2,10 @@
 //  DocumentManifestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/DocumentReferenceTests.swift
+++ b/firekit/firekitTests/classes/DocumentReferenceTests.swift
@@ -2,10 +2,10 @@
 //  DocumentReferenceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/EligibilityRequestTests.swift
+++ b/firekit/firekitTests/classes/EligibilityRequestTests.swift
@@ -2,10 +2,10 @@
 //  EligibilityRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/EligibilityResponseTests.swift
+++ b/firekit/firekitTests/classes/EligibilityResponseTests.swift
@@ -2,10 +2,10 @@
 //  EligibilityResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/EncounterTests.swift
+++ b/firekit/firekitTests/classes/EncounterTests.swift
@@ -2,10 +2,10 @@
 //  EncounterTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/EnrollmentRequestTests.swift
+++ b/firekit/firekitTests/classes/EnrollmentRequestTests.swift
@@ -2,10 +2,10 @@
 //  EnrollmentRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/EnrollmentResponseTests.swift
+++ b/firekit/firekitTests/classes/EnrollmentResponseTests.swift
@@ -2,10 +2,10 @@
 //  EnrollmentResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/EpisodeOfCareTests.swift
+++ b/firekit/firekitTests/classes/EpisodeOfCareTests.swift
@@ -2,10 +2,10 @@
 //  EpisodeOfCareTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ExplanationOfBenefitTests.swift
+++ b/firekit/firekitTests/classes/ExplanationOfBenefitTests.swift
@@ -2,10 +2,10 @@
 //  ExplanationOfBenefitTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/FamilyMemberHistoryTests.swift
+++ b/firekit/firekitTests/classes/FamilyMemberHistoryTests.swift
@@ -2,10 +2,10 @@
 //  FamilyMemberHistoryTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/FlagTests.swift
+++ b/firekit/firekitTests/classes/FlagTests.swift
@@ -2,10 +2,10 @@
 //  FlagTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/GoalTests.swift
+++ b/firekit/firekitTests/classes/GoalTests.swift
@@ -2,10 +2,10 @@
 //  GoalTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/GroupTests.swift
+++ b/firekit/firekitTests/classes/GroupTests.swift
@@ -2,10 +2,10 @@
 //  GroupTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/HealthcareServiceTests.swift
+++ b/firekit/firekitTests/classes/HealthcareServiceTests.swift
@@ -2,10 +2,10 @@
 //  HealthcareServiceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ImagingObjectSelectionTests.swift
+++ b/firekit/firekitTests/classes/ImagingObjectSelectionTests.swift
@@ -2,10 +2,10 @@
 //  ImagingObjectSelectionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ImagingStudyTests.swift
+++ b/firekit/firekitTests/classes/ImagingStudyTests.swift
@@ -2,10 +2,10 @@
 //  ImagingStudyTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ImmunizationRecommendationTests.swift
+++ b/firekit/firekitTests/classes/ImmunizationRecommendationTests.swift
@@ -2,10 +2,10 @@
 //  ImmunizationRecommendationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ImmunizationTests.swift
+++ b/firekit/firekitTests/classes/ImmunizationTests.swift
@@ -2,10 +2,10 @@
 //  ImmunizationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ImplementationGuideTests.swift
+++ b/firekit/firekitTests/classes/ImplementationGuideTests.swift
@@ -2,10 +2,10 @@
 //  ImplementationGuideTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ListTests.swift
+++ b/firekit/firekitTests/classes/ListTests.swift
@@ -2,10 +2,10 @@
 //  ListTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/LocationTests.swift
+++ b/firekit/firekitTests/classes/LocationTests.swift
@@ -2,10 +2,10 @@
 //  LocationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/MediaTests.swift
+++ b/firekit/firekitTests/classes/MediaTests.swift
@@ -2,10 +2,10 @@
 //  MediaTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/MedicationOrderTests.swift
+++ b/firekit/firekitTests/classes/MedicationOrderTests.swift
@@ -2,10 +2,10 @@
 //  MedicationOrderTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/MedicationTests.swift
+++ b/firekit/firekitTests/classes/MedicationTests.swift
@@ -2,10 +2,10 @@
 //  MedicationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/MessageHeaderTests.swift
+++ b/firekit/firekitTests/classes/MessageHeaderTests.swift
@@ -2,10 +2,10 @@
 //  MessageHeaderTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/NamingSystemTests.swift
+++ b/firekit/firekitTests/classes/NamingSystemTests.swift
@@ -2,10 +2,10 @@
 //  NamingSystemTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/NutritionOrderTests.swift
+++ b/firekit/firekitTests/classes/NutritionOrderTests.swift
@@ -2,10 +2,10 @@
 //  NutritionOrderTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ObservationTests.swift
+++ b/firekit/firekitTests/classes/ObservationTests.swift
@@ -2,10 +2,10 @@
 //  ObservationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/OperationDefinitionTests.swift
+++ b/firekit/firekitTests/classes/OperationDefinitionTests.swift
@@ -2,10 +2,10 @@
 //  OperationDefinitionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/OperationOutcomeTests.swift
+++ b/firekit/firekitTests/classes/OperationOutcomeTests.swift
@@ -2,10 +2,10 @@
 //  OperationOutcomeTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/OrderResponseTests.swift
+++ b/firekit/firekitTests/classes/OrderResponseTests.swift
@@ -2,10 +2,10 @@
 //  OrderResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/OrderTests.swift
+++ b/firekit/firekitTests/classes/OrderTests.swift
@@ -2,10 +2,10 @@
 //  OrderTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/OrganizationTests.swift
+++ b/firekit/firekitTests/classes/OrganizationTests.swift
@@ -2,10 +2,10 @@
 //  OrganizationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ParametersTests.swift
+++ b/firekit/firekitTests/classes/ParametersTests.swift
@@ -2,10 +2,10 @@
 //  ParametersTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/PatientTests.swift
+++ b/firekit/firekitTests/classes/PatientTests.swift
@@ -2,10 +2,10 @@
 //  PatientTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 
@@ -73,9 +73,6 @@ class PatientTests: XCTestCase, RealmPersistenceTesting {
     func testPatient1NillingPopulatability() {
         do {
             let instance = try runPatient1()
-            instance.meta = Meta()
-            instance.meta!.lastUpdated = Instant.now
-            instance.meta!.versionId = "1"
             try! realm.write { realm.add(instance) }
             try! realm.write { instance.populate(from: FireKit.Patient()) }
         } catch let error {

--- a/firekit/firekitTests/classes/PaymentNoticeTests.swift
+++ b/firekit/firekitTests/classes/PaymentNoticeTests.swift
@@ -2,10 +2,10 @@
 //  PaymentNoticeTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/PaymentReconciliationTests.swift
+++ b/firekit/firekitTests/classes/PaymentReconciliationTests.swift
@@ -2,10 +2,10 @@
 //  PaymentReconciliationTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/PersonTests.swift
+++ b/firekit/firekitTests/classes/PersonTests.swift
@@ -2,10 +2,10 @@
 //  PersonTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/PractitionerTests.swift
+++ b/firekit/firekitTests/classes/PractitionerTests.swift
@@ -2,10 +2,10 @@
 //  PractitionerTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ProcedureRequestTests.swift
+++ b/firekit/firekitTests/classes/ProcedureRequestTests.swift
@@ -2,10 +2,10 @@
 //  ProcedureRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ProcedureTests.swift
+++ b/firekit/firekitTests/classes/ProcedureTests.swift
@@ -2,10 +2,10 @@
 //  ProcedureTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ProcessRequestTests.swift
+++ b/firekit/firekitTests/classes/ProcessRequestTests.swift
@@ -2,10 +2,10 @@
 //  ProcessRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ProcessResponseTests.swift
+++ b/firekit/firekitTests/classes/ProcessResponseTests.swift
@@ -2,10 +2,10 @@
 //  ProcessResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ProvenanceTests.swift
+++ b/firekit/firekitTests/classes/ProvenanceTests.swift
@@ -2,10 +2,10 @@
 //  ProvenanceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/QuestionnaireResponseTests.swift
+++ b/firekit/firekitTests/classes/QuestionnaireResponseTests.swift
@@ -2,10 +2,10 @@
 //  QuestionnaireResponseTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/QuestionnaireTests.swift
+++ b/firekit/firekitTests/classes/QuestionnaireTests.swift
@@ -2,10 +2,10 @@
 //  QuestionnaireTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ReferralRequestTests.swift
+++ b/firekit/firekitTests/classes/ReferralRequestTests.swift
@@ -2,10 +2,10 @@
 //  ReferralRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/RelatedPersonTests.swift
+++ b/firekit/firekitTests/classes/RelatedPersonTests.swift
@@ -2,10 +2,10 @@
 //  RelatedPersonTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/RiskAssessmentTests.swift
+++ b/firekit/firekitTests/classes/RiskAssessmentTests.swift
@@ -2,10 +2,10 @@
 //  RiskAssessmentTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ScheduleTests.swift
+++ b/firekit/firekitTests/classes/ScheduleTests.swift
@@ -2,10 +2,10 @@
 //  ScheduleTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SearchParameterTests.swift
+++ b/firekit/firekitTests/classes/SearchParameterTests.swift
@@ -2,10 +2,10 @@
 //  SearchParameterTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SlotTests.swift
+++ b/firekit/firekitTests/classes/SlotTests.swift
@@ -2,10 +2,10 @@
 //  SlotTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SpecimenTests.swift
+++ b/firekit/firekitTests/classes/SpecimenTests.swift
@@ -2,10 +2,10 @@
 //  SpecimenTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/StructureDefinitionTests.swift
+++ b/firekit/firekitTests/classes/StructureDefinitionTests.swift
@@ -2,10 +2,10 @@
 //  StructureDefinitionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SubscriptionTests.swift
+++ b/firekit/firekitTests/classes/SubscriptionTests.swift
@@ -2,10 +2,10 @@
 //  SubscriptionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SubstanceTests.swift
+++ b/firekit/firekitTests/classes/SubstanceTests.swift
@@ -2,10 +2,10 @@
 //  SubstanceTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SupplyDeliveryTests.swift
+++ b/firekit/firekitTests/classes/SupplyDeliveryTests.swift
@@ -2,10 +2,10 @@
 //  SupplyDeliveryTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/SupplyRequestTests.swift
+++ b/firekit/firekitTests/classes/SupplyRequestTests.swift
@@ -2,10 +2,10 @@
 //  SupplyRequestTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/TestScriptTests.swift
+++ b/firekit/firekitTests/classes/TestScriptTests.swift
@@ -2,10 +2,10 @@
 //  TestScriptTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/ValueSetTests.swift
+++ b/firekit/firekitTests/classes/ValueSetTests.swift
@@ -2,10 +2,10 @@
 //  ValueSetTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 

--- a/firekit/firekitTests/classes/VisionPrescriptionTests.swift
+++ b/firekit/firekitTests/classes/VisionPrescriptionTests.swift
@@ -2,10 +2,10 @@
 //  VisionPrescriptionTests.swift
 //  FireKit
 //
-//  Generated from FHIR 1.0.2.7202 on 2017-10-22.
+//  Generated from FHIR 1.0.2.7202 on 2017-11-07.
 //  2017, SMART Health IT.
 //
-// Updated for Realm support by Ryan Baldwin on 2017-10-22
+// Updated for Realm support by Ryan Baldwin on 2017-11-07
 // Copyright @ 2017 Bunnyhug. All rights fall under Apache 2
 // 
 


### PR DESCRIPTION
There were times when references would be shared across Resource boundaries, which is a big no no. This fix ensures that using `upsert` and `populateFrom` will no longer do that, and that all types in RealmTypes.swift conform to NSCopying